### PR TITLE
Improve device model

### DIFF
--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/Constants.java
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/Constants.java
@@ -1,7 +1,5 @@
 package me.rapierxbox.shellyelevatev2;
 
-import java.util.HashMap;
-
 public class Constants {
     public static final String SHARED_PREFERENCES_NAME = "ShellyElevateV2";
 
@@ -54,30 +52,4 @@ public class Constants {
 
     public static final String MQTT_TOPIC_HOME_ASSISTANT_STATUS = "homeassistant/status";
 
-    public static final String DEVICE_STARGATE = "SAWD-0A1XX10EU1"; // old one
-    public static final String DEVICE_ATLANTIS = "SAWD-1A1XX10EU1"; // new one
-    public static final String DEVICE_PEGASUS = "SAWD-2A1XX10EU1"; // wide display
-
-    public static final HashMap<String, Boolean> hasProximitySensor = new HashMap<>() {
-        {
-            put(DEVICE_STARGATE, false);
-            put(DEVICE_ATLANTIS, false);
-            put(DEVICE_PEGASUS, true);
-        }
-    };
-    public static final HashMap<String, Double> temperatureOffset = new HashMap<>() {
-        {
-            put(DEVICE_STARGATE, -2.7d);
-            put(DEVICE_ATLANTIS, -1.1d);
-            put(DEVICE_PEGASUS, -2.6d);
-        }
-    };
-
-    public static final HashMap<String, Double> humidityOffset = new HashMap<>() {
-        {
-            put(DEVICE_STARGATE, 7.0d);
-            put(DEVICE_ATLANTIS, 3.0d);
-            put(DEVICE_PEGASUS, 8.0d);
-        }
-    };
 }

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/DeviceModel.java
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/DeviceModel.java
@@ -1,0 +1,37 @@
+package me.rapierxbox.shellyelevatev2;
+
+import static me.rapierxbox.shellyelevatev2.Constants.SP_DEVICE;
+
+import android.content.SharedPreferences;
+
+import androidx.annotation.Nullable;
+
+import java.util.Arrays;
+
+public enum DeviceModel {
+    STARGATE("Stargate", "SAWD-0A1XX10EU1", false, -2.7d, 7.0d), // Old One
+    ATLANTIS("Atlantis", "SAWD-1A1XX10EU1", false, -1.1d, 3.0d), // New One
+    PEGASUS("Pegasus", "SAWD-2A1XX10EU1", true, -2.6d, 8.0d);
+
+    private final String codeName;
+    final String boardName;
+    public final boolean hasProximitySensor;
+    public final double temperatureOffset;
+    public final double humidityOffset;
+
+    DeviceModel(String codeName, String boardName, boolean hasProximitySensor, double temperatureOffset, double humidityOffset) {
+        this.codeName = codeName;
+        this.boardName = boardName;
+        this.hasProximitySensor = hasProximitySensor;
+        this.temperatureOffset = temperatureOffset;
+        this.humidityOffset = humidityOffset;
+    }
+
+    public static DeviceModel getDevice(@Nullable String codename) {
+        return Arrays.stream(DeviceModel.values()).filter(deviceType -> deviceType.boardName.equals(codename)).findFirst().orElse(DeviceModel.STARGATE);
+    }
+
+    public static DeviceModel getDevice(SharedPreferences sharedPreferences) {
+        return getDevice(sharedPreferences.getString(SP_DEVICE, ""));
+    }
+}

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/DeviceModel.java
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/DeviceModel.java
@@ -3,6 +3,7 @@ package me.rapierxbox.shellyelevatev2;
 import static me.rapierxbox.shellyelevatev2.Constants.SP_DEVICE;
 
 import android.content.SharedPreferences;
+import android.os.Build;
 
 import androidx.annotation.Nullable;
 
@@ -14,28 +15,35 @@ public enum DeviceModel {
     ATLANTIS("Atlantis", "SAWD-1A1XX10EU1", false, -1.1d, 3.0d), // New One
     PEGASUS("Pegasus", "SAWD-2A1XX10EU1", true, -2.6d, 8.0d),
 
-    private final String codeName;
-    final String boardName;
     //V2
     BLAKE("Blake", "SAWD-3A1XE10EU2", true, -2.6d, 10.0d),
     MAVERICK("Maverick", "SAWD-4A1XE10US0", true, 0d, 0.0d),
     JENNA("Jenna", "SAWD-5A1XX10EU0", true, 0d, 0.0d);
+
+    private final String model;
+    final String modelName;
     public final boolean hasProximitySensor;
     public final double temperatureOffset;
     public final double humidityOffset;
 
-    DeviceModel(String codeName, String boardName, boolean hasProximitySensor, double temperatureOffset, double humidityOffset) {
-        this.codeName = codeName;
-        this.boardName = boardName;
+    DeviceModel(String model, String modelName, boolean hasProximitySensor, double temperatureOffset, double humidityOffset) {
+        this.model = model;
+        this.modelName = modelName;
         this.hasProximitySensor = hasProximitySensor;
         this.temperatureOffset = temperatureOffset;
         this.humidityOffset = humidityOffset;
     }
 
-    public static DeviceModel getDevice(@Nullable String codename) {
-        return Arrays.stream(DeviceModel.values()).filter(deviceType -> deviceType.boardName.equals(codename)).findFirst().orElse(DeviceModel.STARGATE);
+    public static DeviceModel getReportedDevice(){
+        return Arrays.stream(DeviceModel.values()).filter(deviceType -> deviceType.model.equals(Build.MODEL)).findFirst().orElse(DeviceModel.STARGATE);
     }
 
+    @Deprecated
+    public static DeviceModel getDevice(@Nullable String codename) {
+        return Arrays.stream(DeviceModel.values()).filter(deviceType -> deviceType.modelName.equals(codename)).findFirst().orElse(getReportedDevice());
+    }
+
+    @Deprecated
     public static DeviceModel getDevice(SharedPreferences sharedPreferences) {
         return getDevice(sharedPreferences.getString(SP_DEVICE, ""));
     }

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/DeviceModel.java
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/DeviceModel.java
@@ -5,6 +5,7 @@ import static me.rapierxbox.shellyelevatev2.Constants.SP_DEVICE;
 import android.content.SharedPreferences;
 import android.os.Build;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import java.util.Arrays;
@@ -47,5 +48,12 @@ public enum DeviceModel {
     @Deprecated
     public static DeviceModel getDevice(SharedPreferences sharedPreferences) {
         return getDevice(sharedPreferences.getString(SP_DEVICE, ""));
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        //We are using this with the adapter in SettingsActivity
+        return modelName;
     }
 }

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/DeviceModel.java
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/DeviceModel.java
@@ -9,12 +9,17 @@ import androidx.annotation.Nullable;
 import java.util.Arrays;
 
 public enum DeviceModel {
+    //V1
     STARGATE("Stargate", "SAWD-0A1XX10EU1", false, -2.7d, 7.0d), // Old One
     ATLANTIS("Atlantis", "SAWD-1A1XX10EU1", false, -1.1d, 3.0d), // New One
-    PEGASUS("Pegasus", "SAWD-2A1XX10EU1", true, -2.6d, 8.0d);
+    PEGASUS("Pegasus", "SAWD-2A1XX10EU1", true, -2.6d, 8.0d),
 
     private final String codeName;
     final String boardName;
+    //V2
+    BLAKE("Blake", "SAWD-3A1XE10EU2", true, -2.6d, 10.0d),
+    MAVERICK("Maverick", "SAWD-4A1XE10US0", true, 0d, 0.0d),
+    JENNA("Jenna", "SAWD-5A1XX10EU0", true, 0d, 0.0d);
     public final boolean hasProximitySensor;
     public final double temperatureOffset;
     public final double humidityOffset;

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/DeviceModel.java
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/DeviceModel.java
@@ -12,7 +12,7 @@ import java.util.Arrays;
 public enum DeviceModel {
     //V1
     STARGATE("Stargate", "SAWD-0A1XX10EU1", false, -2.7d, 7.0d), // Old One
-    ATLANTIS("Atlantis", "SAWD-1A1XX10EU1", false, -1.1d, 3.0d), // New One
+    ATLANTIS("Atlantis", "SAWD-1A1XX10EU1", true, -1.1d, 3.0d), // New One
     PEGASUS("Pegasus", "SAWD-2A1XX10EU1", true, -2.6d, 8.0d),
 
     //V2

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/DeviceModel.java
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/DeviceModel.java
@@ -16,9 +16,10 @@ public enum DeviceModel {
     PEGASUS("Pegasus", "SAWD-2A1XX10EU1", true, -2.6d, 8.0d),
 
     //V2
-    BLAKE("Blake", "SAWD-3A1XE10EU2", true, -2.6d, 10.0d),
-    MAVERICK("Maverick", "SAWD-4A1XE10US0", true, 0d, 0.0d),
-    JENNA("Jenna", "SAWD-5A1XX10EU0", true, 0d, 0.0d);
+    //BLAKE("Blake", "SAWD-3A1XE10EU2", true, -2.6d, 10.0d),
+    //MAVERICK("Maverick", "SAWD-4A1XE10US0", true, 0d, 0.0d),
+    //JENNA("Jenna", "SAWD-5A1XX10EU0", true, 0d, 0.0d),
+    ;
 
     private final String model;
     final String modelName;

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/HttpServer.java
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/HttpServer.java
@@ -1,11 +1,9 @@
 package me.rapierxbox.shellyelevatev2;
 
-import static me.rapierxbox.shellyelevatev2.Constants.DEVICE_STARGATE;
 import static me.rapierxbox.shellyelevatev2.Constants.INTENT_SETTINGS_CHANGED;
 import static me.rapierxbox.shellyelevatev2.Constants.INTENT_WEBVIEW_INJECT_JAVASCRIPT;
 import static me.rapierxbox.shellyelevatev2.Constants.SP_DEVICE;
 import static me.rapierxbox.shellyelevatev2.Constants.SP_HTTP_SERVER_ENABLED;
-import static me.rapierxbox.shellyelevatev2.Constants.hasProximitySensor;
 import static me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mApplicationContext;
 import static me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mDeviceHelper;
 import static me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mDeviceSensorManager;
@@ -231,6 +229,8 @@ public class HttpServer extends NanoHTTPD {
         String uri = session.getUri();
         JSONObject jsonResponse = new JSONObject();
 
+        DeviceModel device = DeviceModel.getDevice(mSharedPreferences);
+
         switch (uri.replace("/device/", "")) {
             case "relay":
                 if (method.equals(Method.GET)) {
@@ -280,7 +280,8 @@ public class HttpServer extends NanoHTTPD {
                 break;
             case "getProximity":
                 if (method.equals(Method.GET)) {
-                    if (Boolean.TRUE.equals(hasProximitySensor.get(mSharedPreferences.getString(SP_DEVICE, DEVICE_STARGATE)))) {
+
+                    if (device.hasProximitySensor) {
                         jsonResponse.put("success", true);
                         jsonResponse.put("distance", mDeviceSensorManager.getLastMeasuredDistance());
                     } else {

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/SettingsActivity.kt
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/SettingsActivity.kt
@@ -224,7 +224,7 @@ class SettingsActivity : AppCompatActivity() {
 
             val selectedDevice = binding.deviceTypeSpinner.selectedItem as DeviceModel
             // device
-            putString(SP_DEVICE, selectedDevice.boardName)
+            putString(SP_DEVICE, selectedDevice.modelName)
 
             //Functional mode
             putBoolean(SP_LITE_MODE, binding.liteMode.isChecked)

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/SettingsActivity.kt
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/SettingsActivity.kt
@@ -15,9 +15,6 @@ import androidx.core.content.edit
 import androidx.core.view.isVisible
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.google.android.material.slider.Slider
-import me.rapierxbox.shellyelevatev2.Constants.DEVICE_ATLANTIS
-import me.rapierxbox.shellyelevatev2.Constants.DEVICE_PEGASUS
-import me.rapierxbox.shellyelevatev2.Constants.DEVICE_STARGATE
 import me.rapierxbox.shellyelevatev2.Constants.INTENT_SETTINGS_CHANGED
 import me.rapierxbox.shellyelevatev2.Constants.SHARED_PREFERENCES_NAME
 import me.rapierxbox.shellyelevatev2.Constants.SP_AUTOMATIC_BRIGHTNESS
@@ -39,7 +36,6 @@ import me.rapierxbox.shellyelevatev2.Constants.SP_SCREEN_SAVER_ID
 import me.rapierxbox.shellyelevatev2.Constants.SP_SWITCH_ON_SWIPE
 import me.rapierxbox.shellyelevatev2.Constants.SP_WAKE_ON_PROXIMITY
 import me.rapierxbox.shellyelevatev2.Constants.SP_WEBVIEW_URL
-import me.rapierxbox.shellyelevatev2.Constants.hasProximitySensor
 import me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mDeviceHelper
 import me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mHttpServer
 import me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mScreenSaverManager
@@ -56,8 +52,11 @@ class SettingsActivity : AppCompatActivity() {
     private lateinit var binding: SettingsActivityBinding // Declare the binding object
 
     private fun loadValues() {
+
+        val device = DeviceModel.getDevice(mSharedPreferences)
+
         for (i in 0 until binding.deviceTypeSpinner.adapter.count) {
-            if (binding.deviceTypeSpinner.adapter.getItem(i) == mSharedPreferences.getString(SP_DEVICE, DEVICE_ATLANTIS)) {
+            if (binding.deviceTypeSpinner.adapter.getItem(i) == device) {
                 binding.deviceTypeSpinner.setSelection(i)
             }
         }
@@ -87,8 +86,7 @@ class SettingsActivity : AppCompatActivity() {
 
         binding.screenSaverDelayLayout.isVisible = binding.screenSaver.isChecked
         binding.screenSaverTypeLayout.isVisible = binding.screenSaver.isChecked
-        binding.wakeOnProximity.isVisible = binding.screenSaver.isChecked
-                && hasProximitySensor[mSharedPreferences.getString(SP_DEVICE, DEVICE_ATLANTIS)] == true
+        binding.wakeOnProximity.isVisible = binding.screenSaver.isChecked && device.hasProximitySensor
 
         binding.brightnessSettingLayout.isVisible = !binding.automaticBrightness.isChecked
         binding.minBrightnessLayout.isVisible = binding.automaticBrightness.isChecked
@@ -122,20 +120,13 @@ class SettingsActivity : AppCompatActivity() {
         }
 
         binding.screenSaverType.adapter = mScreenSaverManager.screenSaverSpinnerAdapter
-        binding.deviceTypeSpinner.adapter = ArrayAdapter(this, android.R.layout.simple_spinner_item,
-            listOf(
-                DEVICE_STARGATE,
-                DEVICE_ATLANTIS,
-                DEVICE_PEGASUS
-            )).apply{
-            setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
-        }
+        binding.deviceTypeSpinner.adapter = ArrayAdapter(this, android.R.layout.simple_spinner_item, DeviceModel.entries).apply{ setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item) }
 
         loadValues()
 
         binding.deviceTypeSpinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
             override fun onItemSelected(parent: AdapterView<*>, view: View?, position: Int, id: Long) {
-                binding.wakeOnProximity.isVisible = binding.screenSaver.isChecked && hasProximitySensor[mSharedPreferences.getString(SP_DEVICE, DEVICE_ATLANTIS)] == true
+                binding.wakeOnProximity.isVisible = binding.screenSaver.isChecked && (parent.adapter.getItem(position) as DeviceModel).hasProximitySensor
             }
 
             override fun onNothingSelected(AdapterView: AdapterView<*>?) {
@@ -230,8 +221,10 @@ class SettingsActivity : AppCompatActivity() {
 
     private fun saveSettings() {
         getSharedPreferences(SHARED_PREFERENCES_NAME, MODE_PRIVATE).edit {
+
+            val selectedDevice = binding.deviceTypeSpinner.selectedItem as DeviceModel
             // device
-            putString(SP_DEVICE, binding.deviceTypeSpinner.selectedItem.toString())
+            putString(SP_DEVICE, selectedDevice.boardName)
 
             //Functional mode
             putBoolean(SP_LITE_MODE, binding.liteMode.isChecked)
@@ -260,8 +253,7 @@ class SettingsActivity : AppCompatActivity() {
             putBoolean(SP_SCREEN_SAVER_ENABLED, binding.screenSaver.isChecked)
             putInt(SP_SCREEN_SAVER_DELAY, binding.screenSaverDelay.text.toString().toIntOrNull() ?: SCREEN_SAVER_DEFAULT_DELAY)
             putInt(SP_SCREEN_SAVER_ID, binding.screenSaverType.selectedItemPosition)
-            putBoolean(SP_WAKE_ON_PROXIMITY, binding.wakeOnProximity.isChecked
-                    && hasProximitySensor[mSharedPreferences.getString(SP_DEVICE, DEVICE_ATLANTIS)] == true)
+            putBoolean(SP_WAKE_ON_PROXIMITY, binding.wakeOnProximity.isChecked && selectedDevice.hasProximitySensor)
 
             //Http Server
             putBoolean(SP_HTTP_SERVER_ENABLED, binding.httpServerEnabled.isChecked)

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/ShellyElevateApplication.java
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/ShellyElevateApplication.java
@@ -1,10 +1,8 @@
 package me.rapierxbox.shellyelevatev2;
 
-import static me.rapierxbox.shellyelevatev2.Constants.DEVICE_ATLANTIS;
 import static me.rapierxbox.shellyelevatev2.Constants.SHARED_PREFERENCES_NAME;
 import static me.rapierxbox.shellyelevatev2.Constants.SP_DEVICE;
 import static me.rapierxbox.shellyelevatev2.Constants.SP_HTTP_SERVER_ENABLED;
-import static me.rapierxbox.shellyelevatev2.Constants.hasProximitySensor;
 
 import android.app.Application;
 import android.content.Context;
@@ -57,7 +55,10 @@ public class ShellyElevateApplication extends Application {
         SensorManager sensorManager = (SensorManager) getSystemService(Context.SENSOR_SERVICE);
         Sensor lightSensor = sensorManager.getDefaultSensor(Sensor.TYPE_LIGHT);
         sensorManager.registerListener(mDeviceSensorManager, lightSensor, SensorManager.SENSOR_DELAY_NORMAL);
-        if (Boolean.TRUE.equals(hasProximitySensor.get(mSharedPreferences.getString(SP_DEVICE, DEVICE_ATLANTIS)))) {
+
+        DeviceModel device = DeviceModel.getDevice(mSharedPreferences);
+
+        if (device.hasProximitySensor) {
             Sensor proximitySensor = sensorManager.getDefaultSensor(Sensor.TYPE_PROXIMITY);
             Log.d("ShellyElevateApplication", "Default proximity sensor: " + proximitySensor);
             sensorManager.registerListener(mDeviceSensorManager, proximitySensor, SensorManager.SENSOR_DELAY_NORMAL);

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/ShellyElevateJavascriptInterface.java
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/ShellyElevateJavascriptInterface.java
@@ -11,7 +11,7 @@ import android.webkit.JavascriptInterface;
 
 public class ShellyElevateJavascriptInterface {
     @JavascriptInterface
-    public String getDevice() {return DeviceModel.getDevice(mSharedPreferences).boardName;}
+    public String getDevice() {return DeviceModel.getDevice(mSharedPreferences).modelName;}
     @JavascriptInterface
     public boolean getRelay() {return mDeviceHelper.getRelay();}
     @JavascriptInterface

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/ShellyElevateJavascriptInterface.java
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/ShellyElevateJavascriptInterface.java
@@ -11,7 +11,7 @@ import android.webkit.JavascriptInterface;
 
 public class ShellyElevateJavascriptInterface {
     @JavascriptInterface
-    public String getDevice() {return mSharedPreferences.getString(SP_DEVICE, DEVICE_ATLANTIS);}
+    public String getDevice() {return DeviceModel.getDevice(mSharedPreferences).boardName;}
     @JavascriptInterface
     public boolean getRelay() {return mDeviceHelper.getRelay();}
     @JavascriptInterface

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/helper/DeviceHelper.java
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/helper/DeviceHelper.java
@@ -1,11 +1,8 @@
 package me.rapierxbox.shellyelevatev2.helper;
 
-import static me.rapierxbox.shellyelevatev2.Constants.DEVICE_ATLANTIS;
 import static me.rapierxbox.shellyelevatev2.Constants.SP_AUTOMATIC_BRIGHTNESS;
 import static me.rapierxbox.shellyelevatev2.Constants.SP_BRIGHTNESS;
 import static me.rapierxbox.shellyelevatev2.Constants.SP_DEVICE;
-import static me.rapierxbox.shellyelevatev2.Constants.humidityOffset;
-import static me.rapierxbox.shellyelevatev2.Constants.temperatureOffset;
 import static me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mApplicationContext;
 import static me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mDeviceSensorManager;
 import static me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mMQTTServer;
@@ -22,6 +19,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+
+import me.rapierxbox.shellyelevatev2.DeviceModel;
 
 public class DeviceHelper {
     private static final String[] possibleRelayFiles = {
@@ -118,13 +117,16 @@ public class DeviceHelper {
     public double getTemperature() {
         String[] tempSplit = readFileContent(tempAndHumFile).split(":");
         double temp = (Double.parseDouble(tempSplit[1]) * 175.0 / 65535.0) - 45.0;
-        temp += temperatureOffset.get(mSharedPreferences.getString(SP_DEVICE, DEVICE_ATLANTIS));
+
+        temp +=  DeviceModel.getDevice(mSharedPreferences).temperatureOffset;
         return Math.round(temp * 10.0) / 10.0;
     }
     public double getHumidity() {
         String[] humiditySplit = readFileContent(tempAndHumFile).split(":");
         double humidity = Double.parseDouble(humiditySplit[0]) * 100.0 / 65535.0;
-        humidity += humidityOffset.get(mSharedPreferences.getString(SP_DEVICE, DEVICE_ATLANTIS));
+
+        humidity +=  DeviceModel.getDevice(mSharedPreferences).humidityOffset;
+
         return Math.round(humidity);
     }
 

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/mqtt/MQTTServer.java
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/mqtt/MQTTServer.java
@@ -1,6 +1,5 @@
 package me.rapierxbox.shellyelevatev2.mqtt;
 
-import static me.rapierxbox.shellyelevatev2.Constants.DEVICE_STARGATE;
 import static me.rapierxbox.shellyelevatev2.Constants.INTENT_SETTINGS_CHANGED;
 import static me.rapierxbox.shellyelevatev2.Constants.MQTT_TOPIC_CONFIG_DEVICE;
 import static me.rapierxbox.shellyelevatev2.Constants.MQTT_TOPIC_HOME_ASSISTANT_STATUS;
@@ -24,7 +23,6 @@ import static me.rapierxbox.shellyelevatev2.Constants.SP_MQTT_ENABLED;
 import static me.rapierxbox.shellyelevatev2.Constants.SP_MQTT_PASSWORD;
 import static me.rapierxbox.shellyelevatev2.Constants.SP_MQTT_PORT;
 import static me.rapierxbox.shellyelevatev2.Constants.SP_MQTT_USERNAME;
-import static me.rapierxbox.shellyelevatev2.Constants.hasProximitySensor;
 import static me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mApplicationContext;
 import static me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mDeviceHelper;
 import static me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mDeviceSensorManager;
@@ -51,6 +49,8 @@ import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+
+import me.rapierxbox.shellyelevatev2.DeviceModel;
 
 public class MQTTServer {
     private MqttClient mMqttClient;
@@ -149,7 +149,7 @@ public class MQTTServer {
                 publishTempAndHum();
                 publishRelay(mDeviceHelper.getRelay());
                 publishLux(mDeviceSensorManager.getLastMeasuredLux());
-                if (Boolean.TRUE.equals(hasProximitySensor.get(mSharedPreferences.getString(SP_DEVICE, DEVICE_STARGATE)))) {
+                if (DeviceModel.getDevice(mSharedPreferences).hasProximitySensor) {
                     publishProximity(mDeviceSensorManager.getLastMeasuredDistance());
                 }
                 publishSleeping(mScreenSaverManager.isScreenSaverRunning());
@@ -278,7 +278,7 @@ public class MQTTServer {
         luxSensorPayload.put("unique_id", clientId + "_lux");
         components.put(clientId + "_lux", luxSensorPayload);
 
-        if (Boolean.TRUE.equals(hasProximitySensor.get(mSharedPreferences.getString(SP_DEVICE, DEVICE_STARGATE)))) {
+        if (DeviceModel.getDevice(mSharedPreferences).hasProximitySensor) {
             JSONObject proximitySensorPayload = new JSONObject();
             proximitySensorPayload.put("p", "sensor");
             proximitySensorPayload.put("name", "Proximity");

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,7 +21,7 @@
     <string name="http_server_running">Running</string>
     <string name="http_server_not_running">Not running</string>
     <string name="settings_saved">Settings saved</string>
-    <string name="delay_must_be_bigger_then_5s">Delay must be bigger then 5s</string>
+    <string name="delay_must_be_bigger_then_5s">Delay must be longer than 5s</string>
     <string name="settings">Settings</string>
     <string name="broker_port">Broker port</string>
     <string name="username">Username</string>


### PR DESCRIPTION
Device Model can be moved to a Enum class to make code cleaner.

I left the ability for the user to select the device, but we should be able to automatically detect the device model using the Build.MODEL variabe (code already in place). I do not own x2 devices so before doing automatically you should to some check.

Atlantis devices seems to have the proximity sensor, I fixed that.