### PR TITLE
feat: extend swipe gestures to 3/4/5 fingers and improve multi-touch reliability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ local.properties
 app/build/*
 .kotlin/*
 .idea/*
+.vscode/*
 *.sqlite
 /.vs
 build.log

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/Constants.java
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/Constants.java
@@ -193,6 +193,18 @@ public class Constants {
     public static final String SWIPE_EVENT_TYPE_TWO_FINGER_DOWN     = "two_finger_swipe_down";
     public static final String SWIPE_EVENT_TYPE_TWO_FINGER_LEFT     = "two_finger_swipe_left";
     public static final String SWIPE_EVENT_TYPE_TWO_FINGER_RIGHT    = "two_finger_swipe_right";
+    public static final String SWIPE_EVENT_TYPE_THREE_FINGER_UP     = "three_finger_swipe_up";
+    public static final String SWIPE_EVENT_TYPE_THREE_FINGER_DOWN   = "three_finger_swipe_down";
+    public static final String SWIPE_EVENT_TYPE_THREE_FINGER_LEFT   = "three_finger_swipe_left";
+    public static final String SWIPE_EVENT_TYPE_THREE_FINGER_RIGHT  = "three_finger_swipe_right";
+    public static final String SWIPE_EVENT_TYPE_FOUR_FINGER_UP      = "four_finger_swipe_up";
+    public static final String SWIPE_EVENT_TYPE_FOUR_FINGER_DOWN    = "four_finger_swipe_down";
+    public static final String SWIPE_EVENT_TYPE_FOUR_FINGER_LEFT    = "four_finger_swipe_left";
+    public static final String SWIPE_EVENT_TYPE_FOUR_FINGER_RIGHT   = "four_finger_swipe_right";
+    public static final String SWIPE_EVENT_TYPE_FIVE_FINGER_UP      = "five_finger_swipe_up";
+    public static final String SWIPE_EVENT_TYPE_FIVE_FINGER_DOWN    = "five_finger_swipe_down";
+    public static final String SWIPE_EVENT_TYPE_FIVE_FINGER_LEFT    = "five_finger_swipe_left";
+    public static final String SWIPE_EVENT_TYPE_FIVE_FINGER_RIGHT   = "five_finger_swipe_right";
 
     //Dimmer MQTT Topics
     public static final String MQTT_TOPIC_DIMMER_STATE   = "shellyelevatev2/%s/dimmer";

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/Constants.java
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/Constants.java
@@ -13,6 +13,7 @@ public class Constants {
 
     //IO SP Keys
     public static final String SP_SWITCH_ON_SWIPE = "switchOnSwipe";
+    public static final String SP_PUBLISH_SWIPE_EVENTS = "publishSwipeEvents";
     public static final String SP_POWER_BUTTON_AUTO_REBOOT = "powerButtonAutoReboot";
     public static final String SP_BUTTON_RELAY_ENABLED = "buttonRelayEnabled";
     public static final String SP_BUTTON_RELAY_MAP_FORMAT = "buttonRelayMap%d";

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/MainActivity.kt
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/MainActivity.kt
@@ -618,7 +618,6 @@ class MainActivity : ComponentActivity() {
             setOnTouchListener { _, event ->
                 val sm = ShellyElevateApplication.mScreenManager
                 val consumeForWake = sm?.shouldConsumeTouchForWake() == true
-                Log.i("MainActivity", "WebView onTouch action=${event.actionMasked} pointers=${event.pointerCount} consumeForWake=$consumeForWake")
                 if (BuildConfig.DEBUG) Log.d("MainActivity", "Touch event detected on WebView, mScreenManager=$sm, consumeForWake=$consumeForWake")
                 // SwipeHelper is fed exclusively by GestureInterceptLayout.
                 mScreenSaverManager.onTouchEvent(event)
@@ -783,7 +782,6 @@ class MainActivity : ComponentActivity() {
     @SuppressLint("ClickableViewAccessibility")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        Log.i("MainActivity", "onCreate buildType=${BuildConfig.BUILD_TYPE} debug=${BuildConfig.DEBUG} version=${BuildConfig.VERSION_NAME}")
 
         ServiceHelper.ensureKioskService(applicationContext)
 

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/MainActivity.kt
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/MainActivity.kt
@@ -71,6 +71,7 @@ import me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mSwipeHelper
 import me.rapierxbox.shellyelevatev2.databinding.MainActivityBinding
 import me.rapierxbox.shellyelevatev2.helper.ServiceHelper
 import me.rapierxbox.shellyelevatev2.helper.ButtonPressDetector
+import me.rapierxbox.shellyelevatev2.helper.GestureInterceptLayout
 import me.rapierxbox.shellyelevatev2.helper.WebViewUpdater
 import me.rapierxbox.shellyelevatev2.Constants.SP_WEBVIEW_UPDATE_PROMPTED
 import androidx.appcompat.app.AlertDialog
@@ -618,7 +619,7 @@ class MainActivity : ComponentActivity() {
                 val sm = ShellyElevateApplication.mScreenManager
                 val consumeForWake = sm?.shouldConsumeTouchForWake() == true
                 if (BuildConfig.DEBUG) Log.d("MainActivity", "Touch event detected on WebView, mScreenManager=$sm, consumeForWake=$consumeForWake")
-                mSwipeHelper?.onTouchEvent(event)
+                // SwipeHelper is fed exclusively by GestureInterceptLayout.
                 mScreenSaverManager.onTouchEvent(event)
                 sm?.onTouchEvent()
                 // Returning true consumes the event so it isn't delivered to the WebView.
@@ -798,7 +799,7 @@ class MainActivity : ComponentActivity() {
 
         configureWebView()
         setupSettingsButtons()
-        setupSwipeOverlay()
+        (binding.root as GestureInterceptLayout).swipeHelper = mSwipeHelper
 
         registerBroadcastReceivers()
         applyScoreBarSetting()
@@ -811,17 +812,6 @@ class MainActivity : ComponentActivity() {
             if (!isActivityInStack(SettingsActivity::class.java.name)) {
                 startActivity(Intent(this, SettingsActivity::class.java))
             }
-        }
-    }
-
-    @SuppressLint("ClickableViewAccessibility")
-    private fun setupSwipeOverlay() {
-        // forward so wake works when webview is invisible during sleep
-        binding.swipeDetectionOverlay.setOnTouchListener { _, event ->
-            mSwipeHelper?.onTouchEvent(event)
-            mScreenSaverManager.onTouchEvent(event)
-            ShellyElevateApplication.mScreenManager?.onTouchEvent()
-            false
         }
     }
 

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/MainActivity.kt
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/MainActivity.kt
@@ -618,6 +618,7 @@ class MainActivity : ComponentActivity() {
             setOnTouchListener { _, event ->
                 val sm = ShellyElevateApplication.mScreenManager
                 val consumeForWake = sm?.shouldConsumeTouchForWake() == true
+                Log.i("MainActivity", "WebView onTouch action=${event.actionMasked} pointers=${event.pointerCount} consumeForWake=$consumeForWake")
                 if (BuildConfig.DEBUG) Log.d("MainActivity", "Touch event detected on WebView, mScreenManager=$sm, consumeForWake=$consumeForWake")
                 // SwipeHelper is fed exclusively by GestureInterceptLayout.
                 mScreenSaverManager.onTouchEvent(event)
@@ -782,6 +783,7 @@ class MainActivity : ComponentActivity() {
     @SuppressLint("ClickableViewAccessibility")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        Log.i("MainActivity", "onCreate buildType=${BuildConfig.BUILD_TYPE} debug=${BuildConfig.DEBUG} version=${BuildConfig.VERSION_NAME}")
 
         ServiceHelper.ensureKioskService(applicationContext)
 

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/SettingsFragment.kt
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/SettingsFragment.kt
@@ -297,6 +297,7 @@ class SettingsFragment : Fragment() {
             +SwitchPref(binding.mqttHaDiscovery, SP_MQTT_HA_DISCOVERY, true)
 
             +SwitchPref(binding.switchOnSwipe, SP_SWITCH_ON_SWIPE, true)
+            +SwitchPref(binding.publishSwipeEvents, SP_PUBLISH_SWIPE_EVENTS, true)
             +SwitchPref(binding.powerButtonAutoReboot, SP_POWER_BUTTON_AUTO_REBOOT, true)
             +SwitchPref(binding.mediaEnabled, SP_MEDIA_ENABLED, false)
 

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/helper/GestureInterceptLayout.kt
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/helper/GestureInterceptLayout.kt
@@ -30,7 +30,6 @@ class GestureInterceptLayout @JvmOverloads constructor(
     private val downY = SparseArray<Float>()
 
     override fun onInterceptTouchEvent(ev: MotionEvent): Boolean {
-        Log.i(TAG, "onIntercept action=${ev.actionMasked} pointers=${ev.pointerCount} interceptingBefore=$intercepting")
         when (ev.actionMasked) {
             MotionEvent.ACTION_DOWN -> {
                 intercepting = false
@@ -67,12 +66,10 @@ class GestureInterceptLayout @JvmOverloads constructor(
         } else if (BuildConfig.DEBUG && ev.actionMasked == MotionEvent.ACTION_MOVE) {
             Log.d(TAG, "Gesture intercepted by parent layout")
         }
-        Log.i(TAG, "onIntercept return intercepting=$intercepting")
         return intercepting
     }
 
     override fun onTouchEvent(ev: MotionEvent): Boolean {
-        Log.i(TAG, "onTouchEvent action=${ev.actionMasked} pointers=${ev.pointerCount} intercepting=$intercepting")
         swipeHelper?.onTouchEvent(ev)
         if (BuildConfig.DEBUG && (ev.actionMasked == MotionEvent.ACTION_UP || ev.actionMasked == MotionEvent.ACTION_CANCEL)) {
             Log.d(TAG, "onTouchEvent end action=${ev.actionMasked} intercepting=$intercepting")

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/helper/GestureInterceptLayout.kt
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/helper/GestureInterceptLayout.kt
@@ -5,7 +5,9 @@ import android.util.AttributeSet
 import android.util.SparseArray
 import android.view.MotionEvent
 import android.view.ViewConfiguration
+import android.webkit.WebView
 import androidx.constraintlayout.widget.ConstraintLayout
+import me.rapierxbox.shellyelevatev2.R
 import kotlin.math.abs
 
 class GestureInterceptLayout @JvmOverloads constructor(
@@ -42,6 +44,9 @@ class GestureInterceptLayout @JvmOverloads constructor(
             MotionEvent.ACTION_MOVE -> {
                 if (ev.pointerCount >= 2 && !intercepting) {
                     intercepting = shouldStealGesture(ev)
+                    if (intercepting) {
+                        cancelWebViewTouchStream(ev)
+                    }
                 }
             }
         }
@@ -58,6 +63,18 @@ class GestureInterceptLayout @JvmOverloads constructor(
             intercepting = false
         }
         return true
+    }
+
+    private fun cancelWebViewTouchStream(sourceEvent: MotionEvent) {
+        // Explicitly forward a cancel into the WebView's input pipeline when we steal
+        // the gesture mid-sequence. Android's ViewGroup sends this automatically on
+        // the *next* event, but dispatching it immediately avoids a one-frame gap
+        // where the WebView still considers itself the active touch target.
+        val webView = findViewById<WebView?>(R.id.myWebView) ?: return
+        val cancel = MotionEvent.obtain(sourceEvent)
+        cancel.action = MotionEvent.ACTION_CANCEL
+        webView.dispatchTouchEvent(cancel)
+        cancel.recycle()
     }
 
     private fun shouldStealGesture(ev: MotionEvent): Boolean {

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/helper/GestureInterceptLayout.kt
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/helper/GestureInterceptLayout.kt
@@ -30,6 +30,7 @@ class GestureInterceptLayout @JvmOverloads constructor(
     private val downY = SparseArray<Float>()
 
     override fun onInterceptTouchEvent(ev: MotionEvent): Boolean {
+        Log.i(TAG, "onIntercept action=${ev.actionMasked} pointers=${ev.pointerCount} interceptingBefore=$intercepting")
         when (ev.actionMasked) {
             MotionEvent.ACTION_DOWN -> {
                 intercepting = false
@@ -66,10 +67,12 @@ class GestureInterceptLayout @JvmOverloads constructor(
         } else if (BuildConfig.DEBUG && ev.actionMasked == MotionEvent.ACTION_MOVE) {
             Log.d(TAG, "Gesture intercepted by parent layout")
         }
+        Log.i(TAG, "onIntercept return intercepting=$intercepting")
         return intercepting
     }
 
     override fun onTouchEvent(ev: MotionEvent): Boolean {
+        Log.i(TAG, "onTouchEvent action=${ev.actionMasked} pointers=${ev.pointerCount} intercepting=$intercepting")
         swipeHelper?.onTouchEvent(ev)
         if (BuildConfig.DEBUG && (ev.actionMasked == MotionEvent.ACTION_UP || ev.actionMasked == MotionEvent.ACTION_CANCEL)) {
             Log.d(TAG, "onTouchEvent end action=${ev.actionMasked} intercepting=$intercepting")

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/helper/GestureInterceptLayout.kt
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/helper/GestureInterceptLayout.kt
@@ -1,17 +1,23 @@
 package me.rapierxbox.shellyelevatev2.helper
 
+import android.util.Log
 import android.content.Context
 import android.util.AttributeSet
 import android.util.SparseArray
 import android.view.MotionEvent
 import android.view.ViewConfiguration
 import androidx.constraintlayout.widget.ConstraintLayout
+import me.rapierxbox.shellyelevatev2.BuildConfig
 import kotlin.math.abs
 
 class GestureInterceptLayout @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null
 ) : ConstraintLayout(context, attrs) {
+
+    companion object {
+        private const val TAG = "GestureIntercept"
+    }
 
     var swipeHelper: SwipeHelper? = null
 
@@ -31,29 +37,43 @@ class GestureInterceptLayout @JvmOverloads constructor(
                 downY.clear()
                 downX.put(ev.getPointerId(0), ev.x)
                 downY.put(ev.getPointerId(0), ev.y)
+                if (BuildConfig.DEBUG) {
+                    Log.d(TAG, "ACTION_DOWN pointers=${ev.pointerCount} x=${ev.x} y=${ev.y}")
+                }
             }
 
             MotionEvent.ACTION_POINTER_DOWN -> {
                 val idx = ev.actionIndex
                 downX.put(ev.getPointerId(idx), ev.getX(idx))
                 downY.put(ev.getPointerId(idx), ev.getY(idx))
+                if (BuildConfig.DEBUG) {
+                    Log.d(TAG, "ACTION_POINTER_DOWN pointers=${ev.pointerCount} index=$idx")
+                }
             }
 
             MotionEvent.ACTION_MOVE -> {
                 if (ev.pointerCount >= 2 && !intercepting) {
                     intercepting = shouldStealGesture(ev)
+                    if (BuildConfig.DEBUG) {
+                        Log.d(TAG, "ACTION_MOVE pointers=${ev.pointerCount} intercepting=$intercepting")
+                    }
                 }
             }
         }
 
         if (!intercepting) {
             swipeHelper?.onTouchEvent(ev)
+        } else if (BuildConfig.DEBUG && ev.actionMasked == MotionEvent.ACTION_MOVE) {
+            Log.d(TAG, "Gesture intercepted by parent layout")
         }
         return intercepting
     }
 
     override fun onTouchEvent(ev: MotionEvent): Boolean {
         swipeHelper?.onTouchEvent(ev)
+        if (BuildConfig.DEBUG && (ev.actionMasked == MotionEvent.ACTION_UP || ev.actionMasked == MotionEvent.ACTION_CANCEL)) {
+            Log.d(TAG, "onTouchEvent end action=${ev.actionMasked} intercepting=$intercepting")
+        }
         if (ev.actionMasked == MotionEvent.ACTION_UP || ev.actionMasked == MotionEvent.ACTION_CANCEL) {
             intercepting = false
         }
@@ -62,7 +82,10 @@ class GestureInterceptLayout @JvmOverloads constructor(
 
     private fun shouldStealGesture(ev: MotionEvent): Boolean {
         val n = ev.pointerCount
-        if (n < 2) return false
+        if (n < 2) {
+            if (BuildConfig.DEBUG) Log.d(TAG, "shouldStealGesture=false reason=pointerCount_lt_2")
+            return false
+        }
 
         var maxMove = 0f
         var refSign = 0f
@@ -73,8 +96,14 @@ class GestureInterceptLayout @JvmOverloads constructor(
 
         for (i in 0 until n) {
             val id = ev.getPointerId(i)
-            val sx = downX.get(id) ?: return false
-            val sy = downY.get(id) ?: return false
+            val sx = downX.get(id) ?: run {
+                if (BuildConfig.DEBUG) Log.d(TAG, "shouldStealGesture=false reason=missingStartX pointerId=$id")
+                return false
+            }
+            val sy = downY.get(id) ?: run {
+                if (BuildConfig.DEBUG) Log.d(TAG, "shouldStealGesture=false reason=missingStartY pointerId=$id")
+                return false
+            }
             val dx = ev.getX(i) - sx
             val dy = ev.getY(i) - sy
             val mag = maxOf(abs(dx), abs(dy))
@@ -94,9 +123,20 @@ class GestureInterceptLayout @JvmOverloads constructor(
             }
         }
 
-        if (maxMove < touchSlop * 1.5f) return false
-        if (activeCount < 2) return false
-        if (signMismatch || axisMismatch) return false
+        if (maxMove < touchSlop * 1.5f) {
+            if (BuildConfig.DEBUG) Log.d(TAG, "shouldStealGesture=false reason=maxMove_below_threshold maxMove=$maxMove threshold=${touchSlop * 1.5f}")
+            return false
+        }
+        if (activeCount < 2) {
+            if (BuildConfig.DEBUG) Log.d(TAG, "shouldStealGesture=false reason=activeCount_lt_2 activeCount=$activeCount")
+            return false
+        }
+        if (signMismatch || axisMismatch) {
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "shouldStealGesture=false reason=signOrAxisMismatch signMismatch=$signMismatch axisMismatch=$axisMismatch")
+            }
+            return false
+        }
 
         if (n == 2) {
             val id0 = ev.getPointerId(0)
@@ -112,11 +152,15 @@ class GestureInterceptLayout @JvmOverloads constructor(
                     (ev.getY(1) - ev.getY(0)).toDouble()
                 )
                 if (startDist > 0 && abs(curDist - startDist) / startDist > pinchDeltaRatio) {
+                    if (BuildConfig.DEBUG) {
+                        Log.d(TAG, "shouldStealGesture=false reason=pinchDetected startDist=$startDist curDist=$curDist")
+                    }
                     return false
                 }
             }
         }
 
+        if (BuildConfig.DEBUG) Log.d(TAG, "shouldStealGesture=true")
         return true
     }
 }

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/helper/GestureInterceptLayout.kt
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/helper/GestureInterceptLayout.kt
@@ -1,23 +1,17 @@
 package me.rapierxbox.shellyelevatev2.helper
 
-import android.util.Log
 import android.content.Context
 import android.util.AttributeSet
 import android.util.SparseArray
 import android.view.MotionEvent
 import android.view.ViewConfiguration
 import androidx.constraintlayout.widget.ConstraintLayout
-import me.rapierxbox.shellyelevatev2.BuildConfig
 import kotlin.math.abs
 
 class GestureInterceptLayout @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null
 ) : ConstraintLayout(context, attrs) {
-
-    companion object {
-        private const val TAG = "GestureIntercept"
-    }
 
     var swipeHelper: SwipeHelper? = null
 
@@ -37,43 +31,29 @@ class GestureInterceptLayout @JvmOverloads constructor(
                 downY.clear()
                 downX.put(ev.getPointerId(0), ev.x)
                 downY.put(ev.getPointerId(0), ev.y)
-                if (BuildConfig.DEBUG) {
-                    Log.d(TAG, "ACTION_DOWN pointers=${ev.pointerCount} x=${ev.x} y=${ev.y}")
-                }
             }
 
             MotionEvent.ACTION_POINTER_DOWN -> {
                 val idx = ev.actionIndex
                 downX.put(ev.getPointerId(idx), ev.getX(idx))
                 downY.put(ev.getPointerId(idx), ev.getY(idx))
-                if (BuildConfig.DEBUG) {
-                    Log.d(TAG, "ACTION_POINTER_DOWN pointers=${ev.pointerCount} index=$idx")
-                }
             }
 
             MotionEvent.ACTION_MOVE -> {
                 if (ev.pointerCount >= 2 && !intercepting) {
                     intercepting = shouldStealGesture(ev)
-                    if (BuildConfig.DEBUG) {
-                        Log.d(TAG, "ACTION_MOVE pointers=${ev.pointerCount} intercepting=$intercepting")
-                    }
                 }
             }
         }
 
         if (!intercepting) {
             swipeHelper?.onTouchEvent(ev)
-        } else if (BuildConfig.DEBUG && ev.actionMasked == MotionEvent.ACTION_MOVE) {
-            Log.d(TAG, "Gesture intercepted by parent layout")
         }
         return intercepting
     }
 
     override fun onTouchEvent(ev: MotionEvent): Boolean {
         swipeHelper?.onTouchEvent(ev)
-        if (BuildConfig.DEBUG && (ev.actionMasked == MotionEvent.ACTION_UP || ev.actionMasked == MotionEvent.ACTION_CANCEL)) {
-            Log.d(TAG, "onTouchEvent end action=${ev.actionMasked} intercepting=$intercepting")
-        }
         if (ev.actionMasked == MotionEvent.ACTION_UP || ev.actionMasked == MotionEvent.ACTION_CANCEL) {
             intercepting = false
         }
@@ -82,10 +62,7 @@ class GestureInterceptLayout @JvmOverloads constructor(
 
     private fun shouldStealGesture(ev: MotionEvent): Boolean {
         val n = ev.pointerCount
-        if (n < 2) {
-            if (BuildConfig.DEBUG) Log.d(TAG, "shouldStealGesture=false reason=pointerCount_lt_2")
-            return false
-        }
+        if (n < 2) return false
 
         var maxMove = 0f
         var refSign = 0f
@@ -96,14 +73,8 @@ class GestureInterceptLayout @JvmOverloads constructor(
 
         for (i in 0 until n) {
             val id = ev.getPointerId(i)
-            val sx = downX.get(id) ?: run {
-                if (BuildConfig.DEBUG) Log.d(TAG, "shouldStealGesture=false reason=missingStartX pointerId=$id")
-                return false
-            }
-            val sy = downY.get(id) ?: run {
-                if (BuildConfig.DEBUG) Log.d(TAG, "shouldStealGesture=false reason=missingStartY pointerId=$id")
-                return false
-            }
+            val sx = downX.get(id) ?: return false
+            val sy = downY.get(id) ?: return false
             val dx = ev.getX(i) - sx
             val dy = ev.getY(i) - sy
             val mag = maxOf(abs(dx), abs(dy))
@@ -123,20 +94,9 @@ class GestureInterceptLayout @JvmOverloads constructor(
             }
         }
 
-        if (maxMove < touchSlop * 1.5f) {
-            if (BuildConfig.DEBUG) Log.d(TAG, "shouldStealGesture=false reason=maxMove_below_threshold maxMove=$maxMove threshold=${touchSlop * 1.5f}")
-            return false
-        }
-        if (activeCount < 2) {
-            if (BuildConfig.DEBUG) Log.d(TAG, "shouldStealGesture=false reason=activeCount_lt_2 activeCount=$activeCount")
-            return false
-        }
-        if (signMismatch || axisMismatch) {
-            if (BuildConfig.DEBUG) {
-                Log.d(TAG, "shouldStealGesture=false reason=signOrAxisMismatch signMismatch=$signMismatch axisMismatch=$axisMismatch")
-            }
-            return false
-        }
+        if (maxMove < touchSlop * 1.5f) return false
+        if (activeCount < 2) return false
+        if (signMismatch || axisMismatch) return false
 
         if (n == 2) {
             val id0 = ev.getPointerId(0)
@@ -152,15 +112,11 @@ class GestureInterceptLayout @JvmOverloads constructor(
                     (ev.getY(1) - ev.getY(0)).toDouble()
                 )
                 if (startDist > 0 && abs(curDist - startDist) / startDist > pinchDeltaRatio) {
-                    if (BuildConfig.DEBUG) {
-                        Log.d(TAG, "shouldStealGesture=false reason=pinchDetected startDist=$startDist curDist=$curDist")
-                    }
                     return false
                 }
             }
         }
 
-        if (BuildConfig.DEBUG) Log.d(TAG, "shouldStealGesture=true")
         return true
     }
 }

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/helper/GestureInterceptLayout.kt
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/helper/GestureInterceptLayout.kt
@@ -1,0 +1,122 @@
+package me.rapierxbox.shellyelevatev2.helper
+
+import android.content.Context
+import android.util.AttributeSet
+import android.util.SparseArray
+import android.view.MotionEvent
+import android.view.ViewConfiguration
+import androidx.constraintlayout.widget.ConstraintLayout
+import kotlin.math.abs
+
+class GestureInterceptLayout @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null
+) : ConstraintLayout(context, attrs) {
+
+    var swipeHelper: SwipeHelper? = null
+
+    private val touchSlop = ViewConfiguration.get(context).scaledTouchSlop.toFloat()
+    private val minMovePx = touchSlop * 0.3f
+    private val pinchDeltaRatio = 0.35f
+
+    private var intercepting = false
+    private val downX = SparseArray<Float>()
+    private val downY = SparseArray<Float>()
+
+    override fun onInterceptTouchEvent(ev: MotionEvent): Boolean {
+        when (ev.actionMasked) {
+            MotionEvent.ACTION_DOWN -> {
+                intercepting = false
+                downX.clear()
+                downY.clear()
+                downX.put(ev.getPointerId(0), ev.x)
+                downY.put(ev.getPointerId(0), ev.y)
+            }
+
+            MotionEvent.ACTION_POINTER_DOWN -> {
+                val idx = ev.actionIndex
+                downX.put(ev.getPointerId(idx), ev.getX(idx))
+                downY.put(ev.getPointerId(idx), ev.getY(idx))
+            }
+
+            MotionEvent.ACTION_MOVE -> {
+                if (ev.pointerCount >= 2 && !intercepting) {
+                    intercepting = shouldStealGesture(ev)
+                }
+            }
+        }
+
+        if (!intercepting) {
+            swipeHelper?.onTouchEvent(ev)
+        }
+        return intercepting
+    }
+
+    override fun onTouchEvent(ev: MotionEvent): Boolean {
+        swipeHelper?.onTouchEvent(ev)
+        if (ev.actionMasked == MotionEvent.ACTION_UP || ev.actionMasked == MotionEvent.ACTION_CANCEL) {
+            intercepting = false
+        }
+        return true
+    }
+
+    private fun shouldStealGesture(ev: MotionEvent): Boolean {
+        val n = ev.pointerCount
+        if (n < 2) return false
+
+        var maxMove = 0f
+        var refSign = 0f
+        var refIsVertical = false
+        var activeCount = 0
+        var signMismatch = false
+        var axisMismatch = false
+
+        for (i in 0 until n) {
+            val id = ev.getPointerId(i)
+            val sx = downX.get(id) ?: return false
+            val sy = downY.get(id) ?: return false
+            val dx = ev.getX(i) - sx
+            val dy = ev.getY(i) - sy
+            val mag = maxOf(abs(dx), abs(dy))
+            if (mag > maxMove) maxMove = mag
+
+            if (mag < minMovePx) continue
+
+            val isVertical = abs(dy) >= abs(dx)
+            val sign = Math.signum(if (isVertical) dy else dx)
+            activeCount++
+            if (refSign == 0f) {
+                refSign = sign
+                refIsVertical = isVertical
+            } else {
+                if (sign != refSign) signMismatch = true
+                if (isVertical != refIsVertical) axisMismatch = true
+            }
+        }
+
+        if (maxMove < touchSlop * 1.5f) return false
+        if (activeCount < 2) return false
+        if (signMismatch || axisMismatch) return false
+
+        if (n == 2) {
+            val id0 = ev.getPointerId(0)
+            val id1 = ev.getPointerId(1)
+            val sx0 = downX.get(id0)
+            val sy0 = downY.get(id0)
+            val sx1 = downX.get(id1)
+            val sy1 = downY.get(id1)
+            if (sx0 != null && sy0 != null && sx1 != null && sy1 != null) {
+                val startDist = Math.hypot((sx1 - sx0).toDouble(), (sy1 - sy0).toDouble())
+                val curDist = Math.hypot(
+                    (ev.getX(1) - ev.getX(0)).toDouble(),
+                    (ev.getY(1) - ev.getY(0)).toDouble()
+                )
+                if (startDist > 0 && abs(curDist - startDist) / startDist > pinchDeltaRatio) {
+                    return false
+                }
+            }
+        }
+
+        return true
+    }
+}

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/helper/SwipeHelper.java
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/helper/SwipeHelper.java
@@ -57,8 +57,10 @@ public class SwipeHelper {
     }
 
     public boolean onTouchEvent(MotionEvent event) {
+        Log.i(TAG, "onTouchEvent action=" + event.getActionMasked() + " pointers=" + event.getPointerCount());
         if (!mSharedPreferences.getBoolean(SP_SWITCH_ON_SWIPE, true)) {
             if (BuildConfig.DEBUG) Log.d(TAG, "ignored reason=SP_SWITCH_ON_SWIPE_disabled");
+            Log.i(TAG, "ignored reason=SP_SWITCH_ON_SWIPE_disabled");
             return true;
         }
 
@@ -127,6 +129,8 @@ public class SwipeHelper {
         // while still using gestureStartTime for single-finger gestures.
         long refTime = (lastPointerJoinTime > 0) ? lastPointerJoinTime : gestureStartTime;
         long totalTime = Math.max(1, endTime - refTime);
+        Log.i(TAG, "evaluate totalTimeMs=" + totalTime + " trackedPointers=" + pointers.size()
+            + " maxPointerCount=" + maxPointerCount);
         if (BuildConfig.DEBUG) {
             Log.d(TAG, "evaluate totalTimeMs=" + totalTime + " trackedPointers=" + pointers.size()
                 + " maxPointerCount=" + maxPointerCount);

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/helper/SwipeHelper.java
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/helper/SwipeHelper.java
@@ -58,10 +58,8 @@ public class SwipeHelper {
     }
 
     public boolean onTouchEvent(MotionEvent event) {
-        Log.i(TAG, "onTouchEvent action=" + event.getActionMasked() + " pointers=" + event.getPointerCount());
         if (!mSharedPreferences.getBoolean(SP_SWITCH_ON_SWIPE, true)) {
             if (BuildConfig.DEBUG) Log.d(TAG, "ignored reason=SP_SWITCH_ON_SWIPE_disabled");
-            Log.i(TAG, "ignored reason=SP_SWITCH_ON_SWIPE_disabled");
             return true;
         }
 
@@ -130,8 +128,6 @@ public class SwipeHelper {
         // while still using gestureStartTime for single-finger gestures.
         long refTime = (lastPointerJoinTime > 0) ? lastPointerJoinTime : gestureStartTime;
         long totalTime = Math.max(1, endTime - refTime);
-        Log.i(TAG, "evaluate totalTimeMs=" + totalTime + " trackedPointers=" + pointers.size()
-            + " maxPointerCount=" + maxPointerCount);
         if (BuildConfig.DEBUG) {
             Log.d(TAG, "evaluate totalTimeMs=" + totalTime + " trackedPointers=" + pointers.size()
                 + " maxPointerCount=" + maxPointerCount);

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/helper/SwipeHelper.java
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/helper/SwipeHelper.java
@@ -23,15 +23,10 @@ import static me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mMQTTServer
 import static me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mScreenSaverManager;
 import static me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mSharedPreferences;
 
-import android.util.Log;
 import android.util.SparseArray;
 import android.view.MotionEvent;
 
-import me.rapierxbox.shellyelevatev2.BuildConfig;
-
 public class SwipeHelper {
-    private static final String TAG = "SwipeHelper";
-
     // Thresholds for "real swipe" vs. accidental drag. Velocity is px / ms;
     // distance is raw pixels, so values are tied to display density.
     public float minVel = 2.5F;
@@ -58,10 +53,7 @@ public class SwipeHelper {
     }
 
     public boolean onTouchEvent(MotionEvent event) {
-        if (!mSharedPreferences.getBoolean(SP_SWITCH_ON_SWIPE, true)) {
-            if (BuildConfig.DEBUG) Log.d(TAG, "ignored reason=SP_SWITCH_ON_SWIPE_disabled");
-            return true;
-        }
+        if (!mSharedPreferences.getBoolean(SP_SWITCH_ON_SWIPE, true)) return true;
 
         int actionMasked = event.getActionMasked();
         int actionIndex  = event.getActionIndex();
@@ -72,10 +64,6 @@ public class SwipeHelper {
                 pointers.put(event.getPointerId(0), new PointerInfo(event.getX(), event.getY()));
                 maxPointerCount = 1;
                 gestureStartTime = event.getEventTime();
-                if (BuildConfig.DEBUG) {
-                    Log.d(TAG, "ACTION_DOWN pointerId=" + event.getPointerId(0)
-                            + " x=" + event.getX() + " y=" + event.getY());
-                }
                 break;
 
             case MotionEvent.ACTION_POINTER_DOWN: {
@@ -83,11 +71,6 @@ public class SwipeHelper {
                 pointers.put(pid, new PointerInfo(event.getX(actionIndex), event.getY(actionIndex)));
                 if (event.getPointerCount() > maxPointerCount) maxPointerCount = event.getPointerCount();
                 lastPointerJoinTime = event.getEventTime();
-                if (BuildConfig.DEBUG) {
-                    Log.d(TAG, "ACTION_POINTER_DOWN pid=" + pid
-                            + " pointerCount=" + event.getPointerCount()
-                            + " maxPointerCount=" + maxPointerCount);
-                }
                 break;
             }
 
@@ -95,9 +78,6 @@ public class SwipeHelper {
                 int pid = event.getPointerId(actionIndex);
                 PointerInfo p = pointers.get(pid);
                 if (p != null) { p.endX = event.getX(actionIndex); p.endY = event.getY(actionIndex); }
-                if (BuildConfig.DEBUG) {
-                    Log.d(TAG, "ACTION_POINTER_UP pid=" + pid + " tracked=" + (p != null));
-                }
                 break;
             }
 
@@ -105,17 +85,12 @@ public class SwipeHelper {
                 int pid = event.getPointerId(0);
                 PointerInfo p = pointers.get(pid);
                 if (p != null) { p.endX = event.getX(); p.endY = event.getY(); }
-                if (BuildConfig.DEBUG) {
-                    Log.d(TAG, "ACTION_UP pid=" + pid + " trackedPointers=" + pointers.size()
-                            + " maxPointerCount=" + maxPointerCount);
-                }
                 evaluate(event.getEventTime());
                 clearState();
                 break;
             }
 
             case MotionEvent.ACTION_CANCEL:
-                if (BuildConfig.DEBUG) Log.d(TAG, "ACTION_CANCEL");
                 clearState();
                 break;
         }
@@ -128,39 +103,22 @@ public class SwipeHelper {
         // while still using gestureStartTime for single-finger gestures.
         long refTime = (lastPointerJoinTime > 0) ? lastPointerJoinTime : gestureStartTime;
         long totalTime = Math.max(1, endTime - refTime);
-        if (BuildConfig.DEBUG) {
-            Log.d(TAG, "evaluate totalTimeMs=" + totalTime + " trackedPointers=" + pointers.size()
-                + " maxPointerCount=" + maxPointerCount);
-        }
 
         if (maxPointerCount == 1) {
             PointerInfo p = pointers.size() > 0 ? pointers.valueAt(0) : null;
-            if (p == null) {
-                if (BuildConfig.DEBUG) Log.d(TAG, "single-finger reject reason=noPointerData");
-                return;
-            }
+            if (p == null) return;
             float deltaY   = Math.abs(p.startY - p.endY);
             float velocity = deltaY / (float) totalTime;
-            if (BuildConfig.DEBUG) {
-                Log.d(TAG, "single-finger metrics deltaY=" + deltaY + " velocity=" + velocity
-                        + " minDist=" + minDist + " minVel=" + minVel);
-            }
             if (velocity > minVel && deltaY > minDist) {
                 var numRelay = 0;
                 mDeviceHelper.setRelay(numRelay, !mDeviceHelper.getRelay(numRelay));
                 if (mMQTTServer.shouldSend()) mMQTTServer.publishSwipeEvent(SWIPE_EVENT_TYPE_SINGLE);
-                if (BuildConfig.DEBUG) Log.d(TAG, "single-finger accepted relayToggled=true");
-            } else if (BuildConfig.DEBUG) {
-                Log.d(TAG, "single-finger reject reason=threshold velocityOrDistance");
             }
             return;
         }
 
         int count = pointers.size();
-        if (count == 0) {
-            if (BuildConfig.DEBUG) Log.d(TAG, "multi-finger reject reason=noPointers");
-            return;
-        }
+        if (count == 0) return;
 
         float sumDx = 0, sumDy = 0;
         for (int i = 0; i < count; i++) {
@@ -174,37 +132,18 @@ public class SwipeHelper {
         boolean vertical = Math.abs(meanDy) >= Math.abs(meanDx);
         float meanDist   = Math.max(Math.abs(meanDx), Math.abs(meanDy));
         float velocity   = meanDist / (float) totalTime;
-        if (BuildConfig.DEBUG) {
-            Log.d(TAG, "multi-finger metrics meanDx=" + meanDx + " meanDy=" + meanDy
-                    + " meanDist=" + meanDist + " velocity=" + velocity
-                    + " vertical=" + vertical + " count=" + count);
-        }
 
-        if (velocity <= minVel || meanDist <= minDist) {
-            if (BuildConfig.DEBUG) {
-                Log.d(TAG, "multi-finger reject reason=threshold velocityOrDistance");
-            }
-            return;
-        }
+        if (velocity <= minVel || meanDist <= minDist) return;
 
         // reject pinch/divergent: every pointer must agree in sign on the dominant axis
         for (int i = 0; i < count; i++) {
             PointerInfo p = pointers.valueAt(i);
             float delta = vertical ? (p.endY - p.startY) : (p.endX - p.startX);
             float mean  = vertical ? meanDy : meanDx;
-            if (Math.signum(delta) != Math.signum(mean)) {
-                if (BuildConfig.DEBUG) {
-                    Log.d(TAG, "multi-finger reject reason=signMismatch pointerIndex=" + i
-                            + " delta=" + delta + " mean=" + mean);
-                }
-                return;
-            }
+            if (Math.signum(delta) != Math.signum(mean)) return;
         }
 
-        if (!mMQTTServer.shouldSend()) {
-            if (BuildConfig.DEBUG) Log.d(TAG, "multi-finger reject reason=mqttDisabled");
-            return;
-        }
+        if (!mMQTTServer.shouldSend()) return;
 
         String eventUp;
         String eventDown;

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/helper/SwipeHelper.java
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/helper/SwipeHelper.java
@@ -1,7 +1,19 @@
 package me.rapierxbox.shellyelevatev2.helper;
 
 import static me.rapierxbox.shellyelevatev2.Constants.SP_SWITCH_ON_SWIPE;
+import static me.rapierxbox.shellyelevatev2.Constants.SWIPE_EVENT_TYPE_FIVE_FINGER_DOWN;
+import static me.rapierxbox.shellyelevatev2.Constants.SWIPE_EVENT_TYPE_FIVE_FINGER_LEFT;
+import static me.rapierxbox.shellyelevatev2.Constants.SWIPE_EVENT_TYPE_FIVE_FINGER_RIGHT;
+import static me.rapierxbox.shellyelevatev2.Constants.SWIPE_EVENT_TYPE_FIVE_FINGER_UP;
+import static me.rapierxbox.shellyelevatev2.Constants.SWIPE_EVENT_TYPE_FOUR_FINGER_DOWN;
+import static me.rapierxbox.shellyelevatev2.Constants.SWIPE_EVENT_TYPE_FOUR_FINGER_LEFT;
+import static me.rapierxbox.shellyelevatev2.Constants.SWIPE_EVENT_TYPE_FOUR_FINGER_RIGHT;
+import static me.rapierxbox.shellyelevatev2.Constants.SWIPE_EVENT_TYPE_FOUR_FINGER_UP;
 import static me.rapierxbox.shellyelevatev2.Constants.SWIPE_EVENT_TYPE_SINGLE;
+import static me.rapierxbox.shellyelevatev2.Constants.SWIPE_EVENT_TYPE_THREE_FINGER_DOWN;
+import static me.rapierxbox.shellyelevatev2.Constants.SWIPE_EVENT_TYPE_THREE_FINGER_LEFT;
+import static me.rapierxbox.shellyelevatev2.Constants.SWIPE_EVENT_TYPE_THREE_FINGER_RIGHT;
+import static me.rapierxbox.shellyelevatev2.Constants.SWIPE_EVENT_TYPE_THREE_FINGER_UP;
 import static me.rapierxbox.shellyelevatev2.Constants.SWIPE_EVENT_TYPE_TWO_FINGER_DOWN;
 import static me.rapierxbox.shellyelevatev2.Constants.SWIPE_EVENT_TYPE_TWO_FINGER_LEFT;
 import static me.rapierxbox.shellyelevatev2.Constants.SWIPE_EVENT_TYPE_TWO_FINGER_RIGHT;
@@ -23,6 +35,7 @@ public class SwipeHelper {
     // tracks across the full gesture; some fingers may have lifted before ACTION_UP
     private int maxPointerCount = 0;
     private long gestureStartTime = 0;
+    private long lastPointerJoinTime = 0;
 
     private static class PointerInfo {
         float startX, startY, endX, endY;
@@ -35,6 +48,7 @@ public class SwipeHelper {
         pointers.clear();
         maxPointerCount = 0;
         gestureStartTime = 0;
+        lastPointerJoinTime = 0;
     }
 
     public boolean onTouchEvent(MotionEvent event) {
@@ -55,6 +69,7 @@ public class SwipeHelper {
                 int pid = event.getPointerId(actionIndex);
                 pointers.put(pid, new PointerInfo(event.getX(actionIndex), event.getY(actionIndex)));
                 if (event.getPointerCount() > maxPointerCount) maxPointerCount = event.getPointerCount();
+                lastPointerJoinTime = event.getEventTime();
                 break;
             }
 
@@ -83,7 +98,10 @@ public class SwipeHelper {
     }
 
     private void evaluate(long endTime) {
-        long totalTime = Math.max(1, endTime - gestureStartTime);
+        // Measure velocity from the last finger-join timestamp for multi-touch,
+        // while still using gestureStartTime for single-finger gestures.
+        long refTime = (lastPointerJoinTime > 0) ? lastPointerJoinTime : gestureStartTime;
+        long totalTime = Math.max(1, endTime - refTime);
 
         if (maxPointerCount == 1) {
             PointerInfo p = pointers.size() > 0 ? pointers.valueAt(0) : null;
@@ -126,10 +144,38 @@ public class SwipeHelper {
 
         if (!mMQTTServer.shouldSend()) return;
 
-        if (vertical) {
-            mMQTTServer.publishSwipeEvent(meanDy < 0 ? SWIPE_EVENT_TYPE_TWO_FINGER_UP : SWIPE_EVENT_TYPE_TWO_FINGER_DOWN);
+        String eventUp;
+        String eventDown;
+        String eventLeft;
+        String eventRight;
+
+        if (maxPointerCount >= 5) {
+            eventUp = SWIPE_EVENT_TYPE_FIVE_FINGER_UP;
+            eventDown = SWIPE_EVENT_TYPE_FIVE_FINGER_DOWN;
+            eventLeft = SWIPE_EVENT_TYPE_FIVE_FINGER_LEFT;
+            eventRight = SWIPE_EVENT_TYPE_FIVE_FINGER_RIGHT;
+        } else if (maxPointerCount == 4) {
+            eventUp = SWIPE_EVENT_TYPE_FOUR_FINGER_UP;
+            eventDown = SWIPE_EVENT_TYPE_FOUR_FINGER_DOWN;
+            eventLeft = SWIPE_EVENT_TYPE_FOUR_FINGER_LEFT;
+            eventRight = SWIPE_EVENT_TYPE_FOUR_FINGER_RIGHT;
+        } else if (maxPointerCount == 3) {
+            eventUp = SWIPE_EVENT_TYPE_THREE_FINGER_UP;
+            eventDown = SWIPE_EVENT_TYPE_THREE_FINGER_DOWN;
+            eventLeft = SWIPE_EVENT_TYPE_THREE_FINGER_LEFT;
+            eventRight = SWIPE_EVENT_TYPE_THREE_FINGER_RIGHT;
         } else {
-            mMQTTServer.publishSwipeEvent(meanDx < 0 ? SWIPE_EVENT_TYPE_TWO_FINGER_LEFT : SWIPE_EVENT_TYPE_TWO_FINGER_RIGHT);
+            // maxPointerCount == 2
+            eventUp = SWIPE_EVENT_TYPE_TWO_FINGER_UP;
+            eventDown = SWIPE_EVENT_TYPE_TWO_FINGER_DOWN;
+            eventLeft = SWIPE_EVENT_TYPE_TWO_FINGER_LEFT;
+            eventRight = SWIPE_EVENT_TYPE_TWO_FINGER_RIGHT;
+        }
+
+        if (vertical) {
+            mMQTTServer.publishSwipeEvent(meanDy < 0 ? eventUp : eventDown);
+        } else {
+            mMQTTServer.publishSwipeEvent(meanDx < 0 ? eventLeft : eventRight);
         }
     }
 }

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/helper/SwipeHelper.java
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/helper/SwipeHelper.java
@@ -18,6 +18,7 @@ import static me.rapierxbox.shellyelevatev2.Constants.SWIPE_EVENT_TYPE_TWO_FINGE
 import static me.rapierxbox.shellyelevatev2.Constants.SWIPE_EVENT_TYPE_TWO_FINGER_LEFT;
 import static me.rapierxbox.shellyelevatev2.Constants.SWIPE_EVENT_TYPE_TWO_FINGER_RIGHT;
 import static me.rapierxbox.shellyelevatev2.Constants.SWIPE_EVENT_TYPE_TWO_FINGER_UP;
+import static me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mApplicationContext;
 import static me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mDeviceHelper;
 import static me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mMQTTServer;
 import static me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mScreenSaverManager;
@@ -34,8 +35,11 @@ public class SwipeHelper {
 
     // Thresholds for "real swipe" vs. accidental drag. Velocity is px / ms;
     // distance is raw pixels, so values are tied to display density.
-    public float minVel = 2.5F;
-    public float minDist = 250.0F;
+    public float minVel = 1.0F; // px/ms = 1000 px/s
+    public float minDist = Math.min(
+        mApplicationContext.getResources().getDisplayMetrics().widthPixels,
+        mApplicationContext.getResources().getDisplayMetrics().heightPixels
+    ) / 3.0F; // px
 
     private final SparseArray<PointerInfo> pointers = new SparseArray<>();
     // tracks across the full gesture; some fingers may have lifted before ACTION_UP

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/helper/SwipeHelper.java
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/helper/SwipeHelper.java
@@ -18,6 +18,7 @@ import static me.rapierxbox.shellyelevatev2.Constants.SWIPE_EVENT_TYPE_TWO_FINGE
 import static me.rapierxbox.shellyelevatev2.Constants.SWIPE_EVENT_TYPE_TWO_FINGER_LEFT;
 import static me.rapierxbox.shellyelevatev2.Constants.SWIPE_EVENT_TYPE_TWO_FINGER_RIGHT;
 import static me.rapierxbox.shellyelevatev2.Constants.SWIPE_EVENT_TYPE_TWO_FINGER_UP;
+import static me.rapierxbox.shellyelevatev2.Constants.SP_PUBLISH_SWIPE_EVENTS;
 import static me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mApplicationContext;
 import static me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mDeviceHelper;
 import static me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mMQTTServer;
@@ -62,8 +63,6 @@ public class SwipeHelper {
     }
 
     public boolean onTouchEvent(MotionEvent event) {
-        if (!mSharedPreferences.getBoolean(SP_SWITCH_ON_SWIPE, true)) return true;
-
         int actionMasked = event.getActionMasked();
         int actionIndex  = event.getActionIndex();
 
@@ -108,6 +107,9 @@ public class SwipeHelper {
     }
 
     private void evaluate(long endTime) {
+        boolean switchOnSwipe = mSharedPreferences.getBoolean(SP_SWITCH_ON_SWIPE, true);
+        boolean publishSwipeEvents = mSharedPreferences.getBoolean(SP_PUBLISH_SWIPE_EVENTS, true);
+
         // Measure velocity from the last finger-join timestamp for multi-touch,
         // while still using gestureStartTime for single-finger gestures.
         long refTime = (lastPointerJoinTime > 0) ? lastPointerJoinTime : gestureStartTime;
@@ -118,7 +120,7 @@ public class SwipeHelper {
             if (p == null) return;
             float deltaY   = Math.abs(p.startY - p.endY);
             float velocity = deltaY / (float) totalTime;
-            if (velocity > minVel && deltaY > minDist) {
+            if (switchOnSwipe && velocity > minVel && deltaY > minDist) {
                 var numRelay = 0;
                 mDeviceHelper.setRelay(numRelay, !mDeviceHelper.getRelay(numRelay));
                 if (mMQTTServer.shouldSend()) mMQTTServer.publishSwipeEvent(SWIPE_EVENT_TYPE_SINGLE);
@@ -152,7 +154,7 @@ public class SwipeHelper {
             if (Math.signum(delta) != Math.signum(mean)) return;
         }
 
-        if (!mMQTTServer.shouldSend()) return;
+        if (!publishSwipeEvents || !mMQTTServer.shouldSend()) return;
 
         String eventUp;
         String eventDown;

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/helper/SwipeHelper.java
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/helper/SwipeHelper.java
@@ -20,6 +20,7 @@ import static me.rapierxbox.shellyelevatev2.Constants.SWIPE_EVENT_TYPE_TWO_FINGE
 import static me.rapierxbox.shellyelevatev2.Constants.SWIPE_EVENT_TYPE_TWO_FINGER_UP;
 import static me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mDeviceHelper;
 import static me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mMQTTServer;
+import static me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mScreenSaverManager;
 import static me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mSharedPreferences;
 
 import android.util.Log;
@@ -239,11 +240,13 @@ public class SwipeHelper {
 
         if (vertical) {
             mMQTTServer.publishSwipeEvent(meanDy < 0 ? eventUp : eventDown);
+            if (mScreenSaverManager != null) mScreenSaverManager.onSwipeFired();
             if (BuildConfig.DEBUG) {
                 Log.d(TAG, "multi-finger accepted event=" + (meanDy < 0 ? eventUp : eventDown));
             }
         } else {
             mMQTTServer.publishSwipeEvent(meanDx < 0 ? eventLeft : eventRight);
+            if (mScreenSaverManager != null) mScreenSaverManager.onSwipeFired();
             if (BuildConfig.DEBUG) {
                 Log.d(TAG, "multi-finger accepted event=" + (meanDx < 0 ? eventLeft : eventRight));
             }

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/helper/SwipeHelper.java
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/helper/SwipeHelper.java
@@ -23,10 +23,15 @@ import static me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mMQTTServer
 import static me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mScreenSaverManager;
 import static me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mSharedPreferences;
 
+import android.util.Log;
 import android.util.SparseArray;
 import android.view.MotionEvent;
 
+import me.rapierxbox.shellyelevatev2.BuildConfig;
+
 public class SwipeHelper {
+    private static final String TAG = "SwipeHelper";
+
     // Thresholds for "real swipe" vs. accidental drag. Velocity is px / ms;
     // distance is raw pixels, so values are tied to display density.
     public float minVel = 2.5F;

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/helper/SwipeHelper.java
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/helper/SwipeHelper.java
@@ -22,10 +22,15 @@ import static me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mDeviceHelp
 import static me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mMQTTServer;
 import static me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mSharedPreferences;
 
+import android.util.Log;
 import android.util.SparseArray;
 import android.view.MotionEvent;
 
+import me.rapierxbox.shellyelevatev2.BuildConfig;
+
 public class SwipeHelper {
+    private static final String TAG = "SwipeHelper";
+
     // Thresholds for "real swipe" vs. accidental drag. Velocity is px / ms;
     // distance is raw pixels, so values are tied to display density.
     public float minVel = 2.5F;
@@ -52,7 +57,10 @@ public class SwipeHelper {
     }
 
     public boolean onTouchEvent(MotionEvent event) {
-        if (!mSharedPreferences.getBoolean(SP_SWITCH_ON_SWIPE, true)) return true;
+        if (!mSharedPreferences.getBoolean(SP_SWITCH_ON_SWIPE, true)) {
+            if (BuildConfig.DEBUG) Log.d(TAG, "ignored reason=SP_SWITCH_ON_SWIPE_disabled");
+            return true;
+        }
 
         int actionMasked = event.getActionMasked();
         int actionIndex  = event.getActionIndex();
@@ -63,6 +71,10 @@ public class SwipeHelper {
                 pointers.put(event.getPointerId(0), new PointerInfo(event.getX(), event.getY()));
                 maxPointerCount = 1;
                 gestureStartTime = event.getEventTime();
+                if (BuildConfig.DEBUG) {
+                    Log.d(TAG, "ACTION_DOWN pointerId=" + event.getPointerId(0)
+                            + " x=" + event.getX() + " y=" + event.getY());
+                }
                 break;
 
             case MotionEvent.ACTION_POINTER_DOWN: {
@@ -70,6 +82,11 @@ public class SwipeHelper {
                 pointers.put(pid, new PointerInfo(event.getX(actionIndex), event.getY(actionIndex)));
                 if (event.getPointerCount() > maxPointerCount) maxPointerCount = event.getPointerCount();
                 lastPointerJoinTime = event.getEventTime();
+                if (BuildConfig.DEBUG) {
+                    Log.d(TAG, "ACTION_POINTER_DOWN pid=" + pid
+                            + " pointerCount=" + event.getPointerCount()
+                            + " maxPointerCount=" + maxPointerCount);
+                }
                 break;
             }
 
@@ -77,6 +94,9 @@ public class SwipeHelper {
                 int pid = event.getPointerId(actionIndex);
                 PointerInfo p = pointers.get(pid);
                 if (p != null) { p.endX = event.getX(actionIndex); p.endY = event.getY(actionIndex); }
+                if (BuildConfig.DEBUG) {
+                    Log.d(TAG, "ACTION_POINTER_UP pid=" + pid + " tracked=" + (p != null));
+                }
                 break;
             }
 
@@ -84,12 +104,17 @@ public class SwipeHelper {
                 int pid = event.getPointerId(0);
                 PointerInfo p = pointers.get(pid);
                 if (p != null) { p.endX = event.getX(); p.endY = event.getY(); }
+                if (BuildConfig.DEBUG) {
+                    Log.d(TAG, "ACTION_UP pid=" + pid + " trackedPointers=" + pointers.size()
+                            + " maxPointerCount=" + maxPointerCount);
+                }
                 evaluate(event.getEventTime());
                 clearState();
                 break;
             }
 
             case MotionEvent.ACTION_CANCEL:
+                if (BuildConfig.DEBUG) Log.d(TAG, "ACTION_CANCEL");
                 clearState();
                 break;
         }
@@ -102,22 +127,39 @@ public class SwipeHelper {
         // while still using gestureStartTime for single-finger gestures.
         long refTime = (lastPointerJoinTime > 0) ? lastPointerJoinTime : gestureStartTime;
         long totalTime = Math.max(1, endTime - refTime);
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, "evaluate totalTimeMs=" + totalTime + " trackedPointers=" + pointers.size()
+                + " maxPointerCount=" + maxPointerCount);
+        }
 
         if (maxPointerCount == 1) {
             PointerInfo p = pointers.size() > 0 ? pointers.valueAt(0) : null;
-            if (p == null) return;
+            if (p == null) {
+                if (BuildConfig.DEBUG) Log.d(TAG, "single-finger reject reason=noPointerData");
+                return;
+            }
             float deltaY   = Math.abs(p.startY - p.endY);
             float velocity = deltaY / (float) totalTime;
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "single-finger metrics deltaY=" + deltaY + " velocity=" + velocity
+                        + " minDist=" + minDist + " minVel=" + minVel);
+            }
             if (velocity > minVel && deltaY > minDist) {
                 var numRelay = 0;
                 mDeviceHelper.setRelay(numRelay, !mDeviceHelper.getRelay(numRelay));
                 if (mMQTTServer.shouldSend()) mMQTTServer.publishSwipeEvent(SWIPE_EVENT_TYPE_SINGLE);
+                if (BuildConfig.DEBUG) Log.d(TAG, "single-finger accepted relayToggled=true");
+            } else if (BuildConfig.DEBUG) {
+                Log.d(TAG, "single-finger reject reason=threshold velocityOrDistance");
             }
             return;
         }
 
         int count = pointers.size();
-        if (count == 0) return;
+        if (count == 0) {
+            if (BuildConfig.DEBUG) Log.d(TAG, "multi-finger reject reason=noPointers");
+            return;
+        }
 
         float sumDx = 0, sumDy = 0;
         for (int i = 0; i < count; i++) {
@@ -131,18 +173,37 @@ public class SwipeHelper {
         boolean vertical = Math.abs(meanDy) >= Math.abs(meanDx);
         float meanDist   = Math.max(Math.abs(meanDx), Math.abs(meanDy));
         float velocity   = meanDist / (float) totalTime;
+        if (BuildConfig.DEBUG) {
+            Log.d(TAG, "multi-finger metrics meanDx=" + meanDx + " meanDy=" + meanDy
+                    + " meanDist=" + meanDist + " velocity=" + velocity
+                    + " vertical=" + vertical + " count=" + count);
+        }
 
-        if (velocity <= minVel || meanDist <= minDist) return;
+        if (velocity <= minVel || meanDist <= minDist) {
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "multi-finger reject reason=threshold velocityOrDistance");
+            }
+            return;
+        }
 
         // reject pinch/divergent: every pointer must agree in sign on the dominant axis
         for (int i = 0; i < count; i++) {
             PointerInfo p = pointers.valueAt(i);
             float delta = vertical ? (p.endY - p.startY) : (p.endX - p.startX);
             float mean  = vertical ? meanDy : meanDx;
-            if (Math.signum(delta) != Math.signum(mean)) return;
+            if (Math.signum(delta) != Math.signum(mean)) {
+                if (BuildConfig.DEBUG) {
+                    Log.d(TAG, "multi-finger reject reason=signMismatch pointerIndex=" + i
+                            + " delta=" + delta + " mean=" + mean);
+                }
+                return;
+            }
         }
 
-        if (!mMQTTServer.shouldSend()) return;
+        if (!mMQTTServer.shouldSend()) {
+            if (BuildConfig.DEBUG) Log.d(TAG, "multi-finger reject reason=mqttDisabled");
+            return;
+        }
 
         String eventUp;
         String eventDown;
@@ -174,8 +235,14 @@ public class SwipeHelper {
 
         if (vertical) {
             mMQTTServer.publishSwipeEvent(meanDy < 0 ? eventUp : eventDown);
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "multi-finger accepted event=" + (meanDy < 0 ? eventUp : eventDown));
+            }
         } else {
             mMQTTServer.publishSwipeEvent(meanDx < 0 ? eventLeft : eventRight);
+            if (BuildConfig.DEBUG) {
+                Log.d(TAG, "multi-finger accepted event=" + (meanDx < 0 ? eventLeft : eventRight));
+            }
         }
     }
 }

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/mqtt/MqttDiscoveryConfigBuilder.java
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/mqtt/MqttDiscoveryConfigBuilder.java
@@ -151,11 +151,23 @@ class MqttDiscoveryConfigBuilder {
         swipe.put("state_topic", parseTopic(MQTT_TOPIC_SWIPE_EVENT));
         swipe.put("device_class", "button");
         swipe.put("event_types", new JSONArray()
-                .put(SWIPE_EVENT_TYPE_SINGLE)
-                .put(SWIPE_EVENT_TYPE_TWO_FINGER_UP)
-                .put(SWIPE_EVENT_TYPE_TWO_FINGER_DOWN)
-                .put(SWIPE_EVENT_TYPE_TWO_FINGER_LEFT)
-                .put(SWIPE_EVENT_TYPE_TWO_FINGER_RIGHT));
+            .put(SWIPE_EVENT_TYPE_SINGLE)
+            .put(SWIPE_EVENT_TYPE_TWO_FINGER_UP)
+            .put(SWIPE_EVENT_TYPE_TWO_FINGER_DOWN)
+            .put(SWIPE_EVENT_TYPE_TWO_FINGER_LEFT)
+            .put(SWIPE_EVENT_TYPE_TWO_FINGER_RIGHT)
+            .put(SWIPE_EVENT_TYPE_THREE_FINGER_UP)
+            .put(SWIPE_EVENT_TYPE_THREE_FINGER_DOWN)
+            .put(SWIPE_EVENT_TYPE_THREE_FINGER_LEFT)
+            .put(SWIPE_EVENT_TYPE_THREE_FINGER_RIGHT)
+            .put(SWIPE_EVENT_TYPE_FOUR_FINGER_UP)
+            .put(SWIPE_EVENT_TYPE_FOUR_FINGER_DOWN)
+            .put(SWIPE_EVENT_TYPE_FOUR_FINGER_LEFT)
+            .put(SWIPE_EVENT_TYPE_FOUR_FINGER_RIGHT)
+            .put(SWIPE_EVENT_TYPE_FIVE_FINGER_UP)
+            .put(SWIPE_EVENT_TYPE_FIVE_FINGER_DOWN)
+            .put(SWIPE_EVENT_TYPE_FIVE_FINGER_LEFT)
+            .put(SWIPE_EVENT_TYPE_FIVE_FINGER_RIGHT));
         swipe.put("unique_id", clientId + "_swipe_event");
         swipe.put("object_id", "shelly_walldisplay_" + clientId + "_swipe_event");
         components.put(clientId + "_swipe_event", swipe);

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/screensavers/ScreenSaverManager.java
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/screensavers/ScreenSaverManager.java
@@ -34,6 +34,8 @@ public class ScreenSaverManager extends BroadcastReceiver {
     private long lastTouchEventTime;
     private volatile boolean screenSaverRunning;
 	private volatile boolean keepAliveFlag = false;
+    // Tracks whether the current touch gesture became multi-touch.
+    private volatile boolean gestureIsMultiTouch = false;
     private long lastProximityWakeTime = 0L;
     private volatile Boolean lastNearState = null;
     private volatile ScheduledFuture<?> idleTask;
@@ -83,14 +85,38 @@ public class ScreenSaverManager extends BroadcastReceiver {
             return true;
         }
 
-        // move events only need the timestamp since onIdleDeadline re-checks it
-        // and reschedules the remainder itself
-        if (event.getAction() == ACTION_DOWN || event.getAction() == ACTION_UP) {
+        int actionMasked = event.getActionMasked();
+
+        if (actionMasked == ACTION_DOWN) {
+            // New gesture starts: assume single-touch until a second pointer joins.
+            gestureIsMultiTouch = false;
             rescheduleIdleCheck();
-            // wake on down so brightness restores as finger lands
+            // Do not wake on DOWN yet; wait for ACTION_UP so multi-touch gestures
+            // can complete while the screensaver remains active.
+        }
+
+        if (actionMasked == MotionEvent.ACTION_POINTER_DOWN) {
+            // Second (or more) finger joined this gesture.
+            gestureIsMultiTouch = true;
+        }
+
+        if (actionMasked == ACTION_UP) {
+            rescheduleIdleCheck();
+            if (isScreenSaverRunning()) {
+                if (!gestureIsMultiTouch) {
+                    // Single-finger tap should still wake the screensaver.
+                    stopScreenSaver();
+                }
+                // Multi-touch gesture: keep screensaver running intentionally.
+            }
+            gestureIsMultiTouch = false;
+        }
+
+        if (actionMasked == MotionEvent.ACTION_CANCEL) {
             if (isScreenSaverRunning()) {
                 stopScreenSaver();
             }
+            gestureIsMultiTouch = false;
         }
         return true;
     }

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/screensavers/ScreenSaverManager.java
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/screensavers/ScreenSaverManager.java
@@ -36,6 +36,8 @@ public class ScreenSaverManager extends BroadcastReceiver {
 	private volatile boolean keepAliveFlag = false;
     // Tracks whether the current touch gesture became multi-touch.
     private volatile boolean gestureIsMultiTouch = false;
+    // Set by SwipeHelper when a multi-finger swipe was successfully recognized.
+    private volatile boolean swipeFired = false;
     private long lastProximityWakeTime = 0L;
     private volatile Boolean lastNearState = null;
     private volatile ScheduledFuture<?> idleTask;
@@ -90,6 +92,7 @@ public class ScreenSaverManager extends BroadcastReceiver {
         if (actionMasked == ACTION_DOWN) {
             // New gesture starts: assume single-touch until a second pointer joins.
             gestureIsMultiTouch = false;
+            swipeFired = false;
             rescheduleIdleCheck();
             // Do not wake on DOWN yet; wait for ACTION_UP so multi-touch gestures
             // can complete while the screensaver remains active.
@@ -103,12 +106,13 @@ public class ScreenSaverManager extends BroadcastReceiver {
         if (actionMasked == ACTION_UP) {
             rescheduleIdleCheck();
             if (isScreenSaverRunning()) {
-                if (!gestureIsMultiTouch) {
-                    // Single-finger tap should still wake the screensaver.
+                if (!swipeFired) {
+                    // Wake on taps (single- and multi-touch). Only keep running
+                    // when a swipe was explicitly recognized for this gesture.
                     stopScreenSaver();
                 }
-                // Multi-touch gesture: keep screensaver running intentionally.
             }
+            swipeFired = false;
             gestureIsMultiTouch = false;
         }
 
@@ -116,9 +120,14 @@ public class ScreenSaverManager extends BroadcastReceiver {
             if (isScreenSaverRunning()) {
                 stopScreenSaver();
             }
+            swipeFired = false;
             gestureIsMultiTouch = false;
         }
         return true;
+    }
+
+    public void onSwipeFired() {
+        swipeFired = true;
     }
 
     public boolean isScreenSaverRunning() {

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/screensavers/ScreenSaverManager.java
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/screensavers/ScreenSaverManager.java
@@ -9,6 +9,8 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.os.Handler;
+import android.os.Looper;
 import android.util.Log;
 import android.view.MotionEvent;
 
@@ -34,6 +36,8 @@ public class ScreenSaverManager extends BroadcastReceiver {
     private long lastTouchEventTime;
     private volatile boolean screenSaverRunning;
 	private volatile boolean keepAliveFlag = false;
+    private final Handler mainHandler = new Handler(Looper.getMainLooper());
+    private long gestureToken = 0L;
     // Tracks whether the current touch gesture became multi-touch.
     private volatile boolean gestureIsMultiTouch = false;
     // Set by SwipeHelper when a multi-finger swipe was successfully recognized.
@@ -91,6 +95,7 @@ public class ScreenSaverManager extends BroadcastReceiver {
 
         if (actionMasked == ACTION_DOWN) {
             // New gesture starts: assume single-touch until a second pointer joins.
+            gestureToken++;
             gestureIsMultiTouch = false;
             swipeFired = false;
             rescheduleIdleCheck();
@@ -105,15 +110,19 @@ public class ScreenSaverManager extends BroadcastReceiver {
 
         if (actionMasked == ACTION_UP) {
             rescheduleIdleCheck();
-            if (isScreenSaverRunning()) {
-                if (!swipeFired) {
+            final long tokenAtUp = gestureToken;
+            // Decide tap-vs-swipe at the end of this dispatch turn so SwipeHelper
+            // can still mark onSwipeFired() even if it receives ACTION_UP later.
+            mainHandler.post(() -> {
+                if (tokenAtUp != gestureToken) return;
+                if (isScreenSaverRunning() && !swipeFired) {
                     // Wake on taps (single- and multi-touch). Only keep running
                     // when a swipe was explicitly recognized for this gesture.
                     stopScreenSaver();
                 }
-            }
-            swipeFired = false;
-            gestureIsMultiTouch = false;
+                swipeFired = false;
+                gestureIsMultiTouch = false;
+            });
         }
 
         if (actionMasked == MotionEvent.ACTION_CANCEL) {

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/screensavers/activities/DigitalClockAndDateScreenSaverActivity.kt
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/screensavers/activities/DigitalClockAndDateScreenSaverActivity.kt
@@ -62,8 +62,6 @@ class DigitalClockAndDateScreenSaverActivity : Activity() {
             Log.d("DigitalClockAndDateScreenSaverActivity", "Received touch event: $event")
             ShellyElevateApplication.mSwipeHelper?.onTouchEvent(event)
             mScreenSaverManager.onTouchEvent(event)
-            ShellyElevateApplication.mScreenManager?.onTouchEvent()
-
             true
         }
 

--- a/app/src/main/res/layout/main_activity.xml
+++ b/app/src/main/res/layout/main_activity.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<me.rapierxbox.shellyelevatev2.helper.GestureInterceptLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -90,17 +90,6 @@
     </com.google.android.material.card.MaterialCardView>
 
     <View
-        android:id="@+id/swipeDetectionOverlay"
-        android:background="@android:color/transparent"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        />
-
-    <View
         android:id="@+id/voiceIndicatorDot"
         android:layout_width="16dp"
         android:layout_height="16dp"
@@ -131,4 +120,4 @@
         app:layout_constraintHeight_percent="0.15"
         app:layout_constraintWidth_percent="0.15" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</me.rapierxbox.shellyelevatev2.helper.GestureInterceptLayout>

--- a/app/src/main/res/layout/settings_fragment.xml
+++ b/app/src/main/res/layout/settings_fragment.xml
@@ -210,6 +210,15 @@
                 tools:ignore="UseSwitchCompatOrMaterialXml" />
 
             <com.google.android.material.materialswitch.MaterialSwitch
+                android:id="@+id/publishSwipeEvents"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                android:text="@string/publishSwipeEventsText"
+                android:textSize="18sp"
+                tools:ignore="UseSwitchCompatOrMaterialXml" />
+
+            <com.google.android.material.materialswitch.MaterialSwitch
                 android:id="@+id/powerButtonAutoReboot"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,7 +3,7 @@
 
     <!-- Sync Preferences -->
     <string name="findIPButtonText">Search for HA URL</string>
-    <string name="switchOnSwipeText">Switch on swipe</string>
+    <string name="switchOnSwipeText">Publish swipe events</string>
     <string name="power_button_auto_reboot">Power Button Auto-Reboot (long press)</string>
     <string name="automaticBrightnessText">Automatic Brightness</string>
     <string name="ScreenSaverText">Screen Saver</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,7 +3,8 @@
 
     <!-- Sync Preferences -->
     <string name="findIPButtonText">Search for HA URL</string>
-    <string name="switchOnSwipeText">Publish swipe events</string>
+    <string name="switchOnSwipeText">Switch on swipe</string>
+    <string name="publishSwipeEventsText">Publish multi-finger swipe events</string>
     <string name="power_button_auto_reboot">Power Button Auto-Reboot (long press)</string>
     <string name="automaticBrightnessText">Automatic Brightness</string>
     <string name="ScreenSaverText">Screen Saver</string>


### PR DESCRIPTION
Fixes #87 

## Summary

This PR extends the swipe gesture system in ShellyElevate with full multi-finger support (3, 4, and 5 simultaneous fingers) and fixes several reliability issues with multi-touch recognition that caused gestures to be missed or mis-classified.

## Changes

### New: `GestureInterceptLayout`
Replaced the transparent `swipeDetectionOverlay` View and the `ConstraintLayout` root with a single custom `GestureInterceptLayout`. The layout intercepts touch events at the view-hierarchy root and forwards them to `SwipeHelper` before the WebView sees them. This resolves a race condition where the WebView would consume multi-touch events before `SwipeHelper` could track all pointers.

Key behaviour:
- Single-touch events pass through to the WebView unchanged.
- Multi-touch gestures are evaluated: if all pointers move in the same direction and the movement exceeds the touch-slop threshold, the layout claims the gesture and hands it exclusively to `SwipeHelper`.
- Pinch gestures (where finger spread changes by > 35%) are explicitly excluded and reach the WebView as normal.
- Swipe behavior now has independent controls: **Switch on swipe** for single-finger relay action and **Publish multi-finger swipe events** for MQTT automation gestures.

Architecture and flowchart:
```
                   FINGER TOUCH
                        │
                        ▼
              ┌─────────────────────┐
              │  GestureIntercept   │
              │      Layout         │
              │  onInterceptTouch   │
              └─────────┬───────────┘
                        │
              ┌─────────┴───────────┐
              │  How many fingers?  │
              └─────────────────────┘
              │                     │
           1 finger            2+ fingers
              │                     │
              │              ┌──────┴──────┐
              │              │  Observing  │◄── pass-through to
              │              │   movement  │    WebView as normal
              │              └──────┬──────┘
              │                     │
              │          ┌──────────┴────────────┐
              │    slop  │                       │ no slop yet
              │ exceeded?│                       │
              │         YES                  keep waiting
              │          │
              │    ┌─────┴──────┐
              │    │  Pinch?    │
              │    └────────────┘
              │     YES     NO
              │      │      │
              │      │      ▼
              │      │  STEAL gesture
              │      │  → ACTION_CANCEL to WebView
              │      │  → SwipeHelper evaluates
              │      │  → MQTT swipe event fired
              │      │
              ▼      ▼
         ┌──────────────────┐
         │     WebView      │
         │  normal touch    │
         │  tap/scroll/     │
         │  pinch-zoom      │
         └──────────────────┘
```


### Extended finger count support (3, 4, 5 fingers)
`SwipeHelper` now maps `maxPointerCount` to the correct `SWIPE_EVENT_TYPE_*` constant for 3-, 4-, and 5-finger gestures. All four directions (up/down/left/right) are supported per finger count.

MQTT discovery config (`MqttDiscoveryConfigBuilder`) now advertises all 17 event types to Home Assistant, so they appear in the HA device trigger UI without manual YAML configuration.

### Multi-touch velocity fix
The velocity measurement for multi-touch gestures now uses the timestamp of the **last** `ACTION_POINTER_DOWN` event as the reference, rather than the initial `ACTION_DOWN`. This prevents false negatives when fingers are placed down sequentially (e.g., 0.2 s between fingers), which inflated the apparent gesture time and caused swipes to fall below the minimum velocity threshold.

### Screensaver interaction fix
`ScreenSaverManager` now distinguishes between taps and recognised swipes:
- A **tap** (no swipe classified) always dismisses the screensaver.
- A **recognised multi-finger swipe** keeps the screensaver active while still publishing the MQTT event.

This allows using swipe gestures to control Home Assistant automations (e.g., adjust lights) without immediately revealing the dashboard.


## Testing

Tested on Shelly Wall Display X2 and X2i models:
- Single-finger fast vertical swipe: relay toggle + `swipe` MQTT event ✓
- Two-, Three-, Four-, Five-finger swipe in all four directions ✓
- Screensaver dismissed by tap ✓
- Screensaver stays on two-finger swipe ✓
- Pinch-to-zoom in HA dashboard not intercepted ✓

### Missing hardware models testing
Testing on other Wall display Models would be very helpful.

## MQTT event types added

| Event value | Fingers |
|---|---|
| `three_finger_swipe_up/down/left/right` | 3 |
| `four_finger_swipe_up/down/left/right` | 4 |
| `five_finger_swipe_up/down/left/right` | 5 |

All existing event types (`swipe`, `two_finger_swipe_*`) are unchanged.

🤖 **AI Disclosure**
Part of this code was generated or optimized using GitHub Copilot:
- Code creation, refinement and completion
- Architecture assessment and consulting
- Functionality validation and troubleshooting