### PR TITLE
feat: add stock-like switch/button input modes for the SW terminal (#1)

### DIFF
--- a/.github/workflows/pr-apk.yml
+++ b/.github/workflows/pr-apk.yml
@@ -1,0 +1,98 @@
+name: Build PR APK
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# a force-push cancels the stale build for the same pr
+concurrency:
+  group: pr-apk-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-pr-apk:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Accept Android SDK licenses
+        run: yes | sdkmanager --licenses
+
+      - name: Install Android platform/build-tools
+        run: sdkmanager "platform-tools" "platforms;android-36" "build-tools;36.0.0"
+
+      - name: Prepare local.properties
+        run: |
+          echo "sdk.dir=$ANDROID_SDK_ROOT" > local.properties
+
+      - name: Ensure gradlew is executable
+        run: chmod +x ./gradlew
+
+      - name: Run unit tests
+        run: ./gradlew testDebugUnitTest --no-daemon --stacktrace
+
+      # unlike the release workflow this does not fail on missing secrets:
+      # fork prs get no secrets and gradle then signs with the debug key
+      - name: Build release APK
+        env:
+          SIGNING_KEYSTORE_BASE64: ${{ secrets.SIGNING_KEYSTORE_BASE64 }}
+          SIGNING_STORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}
+          SIGNING_KEY_ALIAS: ${{ secrets.SIGNING_KEY_ALIAS }}
+          SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
+        run: |
+          if [ -z "$SIGNING_KEYSTORE_BASE64" ]; then
+            echo "::warning::No SIGNING_* secrets configured: this artifact gets an ephemeral debug key and cannot update any previously installed build. Run tools/generate-signing-keystore.sh and add the printed secrets."
+          fi
+          ./gradlew :app:assembleRelease --no-daemon --stacktrace
+
+      - name: Name APK
+        id: apk
+        env:
+          PR_LABEL: ${{ github.event.pull_request.number && format('PR{0}', github.event.pull_request.number) || 'manual' }}
+        run: |
+          VERSION=$(jq -r '.elements[0].versionName' app/build/outputs/apk/release/output-metadata.json)
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          NAME="ShellyElevateV2-${PR_LABEL}-${VERSION}-${SHORT_SHA}"
+          cp app/build/outputs/apk/release/*.apk "${NAME}.apk"
+          echo "name=${NAME}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.apk.outputs.name }}
+          path: ${{ steps.apk.outputs.name }}.apk
+          retention-days: 30
+          if-no-files-found: error
+
+      - name: Job summary
+        env:
+          HAS_RELEASE_KEY: ${{ secrets.SIGNING_KEYSTORE_BASE64 != '' }}
+        run: |
+          {
+            echo "## PR APK"
+            echo ""
+            echo "- version: \`${{ steps.apk.outputs.version }}\`"
+            echo "- commit: \`$(git rev-parse --short HEAD)\`"
+            if [ "$HAS_RELEASE_KEY" = "true" ]; then
+              echo "- signed with the release key (installs in place over a release install)"
+            else
+              echo "- signed with the debug key fallback (cannot update a release-signed install in place)"
+            fi
+            echo ""
+            echo "Download the artifact from this run's page, then: \`adb install -r ${{ steps.apk.outputs.name }}.apk\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ https://github.com/user-attachments/assets/adf46edd-9bf1-45da-b553-bf7781d17fbd
 - MQTT with full Home Assistant auto-discovery (temperature, humidity, light, proximity, relays, inputs, buttons, swipe events, screen brightness and night mode control) — and entities now go `unavailable` in HA when the display drops off the network
 - A REST API on port 8080 for everything the device can do
 - A JavaScript bridge so your dashboard can read sensors and flip relays without going through HA
+- External wall switches and push-buttons on the SW terminal work like stock: Button/Switch input modes with local relay control ([details](docs/sw-input.md))
 - Auto-brightness from the light sensor, screensavers, wake-on-proximity
 - In-app updates for both the app and the WebView, with optional self-install as a system app so updates don't need a cable
 - ADB over Wi-Fi you can toggle from settings, handy once the display is on the wall with no USB reachable

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/Constants.java
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/Constants.java
@@ -16,6 +16,14 @@ public class Constants {
     public static final String SP_POWER_BUTTON_AUTO_REBOOT = "powerButtonAutoReboot";
     public static final String SP_BUTTON_RELAY_ENABLED = "buttonRelayEnabled";
     public static final String SP_BUTTON_RELAY_MAP_FORMAT = "buttonRelayMap%d";
+    // sw terminal input behavior; mirrors the stock firmware input type setting
+    public static final String SP_SW_INPUT_MODE_FORMAT = "swInputMode%d";
+    public static final String SP_SW_INPUT_RELAY_MAP_FORMAT = "swInputRelayMap%d";
+    public static final String SP_SW_INPUT_INVERT_FORMAT = "swInputInvert%d";
+    public static final int SW_INPUT_MODE_DETACHED = 0;
+    public static final int SW_INPUT_MODE_BUTTON = 1;
+    public static final int SW_INPUT_MODE_SWITCH_EDGE = 2;
+    public static final int SW_INPUT_MODE_SWITCH_FOLLOW = 3;
 
     //Webserver SP Keys
     public static final String SP_HTTP_SERVER_ENABLED = "httpServer";

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/DeviceModel.java
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/DeviceModel.java
@@ -30,7 +30,8 @@ public enum DeviceModel {
             .initRelay("cloud.shelly.jenna.relay1", "cloud.shelly.jenna.relay2")
             // event4 is JENNA's proximity gpio_keys node; event5/event7 carry the regular keys.
             .inputEvents("/dev/input/event4", "/dev/input/event5", "/dev/input/event7")),
-    CALLY   (new Config("Cally",    "Shelly Wall Display XLi", "SAWD-6A1XX10EU0")
+    // SAWD-6A1XX10EU0 is the Wall Display X1i per the official knowledge base
+    CALLY   (new Config("Cally",    "Shelly Wall Display X1i", "SAWD-6A1XX10EU0")
             .proximity().powerButton().io(4, 1, 2).panelMinBacklight(3)
             .initRelay("cloud.shelly.cally.relay1", "cloud.shelly.cally.relay2")
             .inputEvents("/dev/input/event3", "/dev/input/event5")),

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/HttpServer.java
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/HttpServer.java
@@ -10,6 +10,7 @@ import static me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mMediaHelpe
 import static me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mNightModeManager;
 import static me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mScreenSaverManager;
 import static me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mSharedPreferences;
+import static me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mSwInputHandler;
 
 import android.content.Intent;
 import android.content.pm.PackageInfo;
@@ -290,6 +291,20 @@ public class HttpServer extends NanoHTTPD {
 
                     jsonResponse.put("success", true);
                     jsonResponse.put("state", mDeviceHelper.getRelay(num));
+                } else {
+                    jsonResponse.put("success", false);
+                    jsonResponse.put("error", "Invalid request method");
+                }
+                break;
+            case "input":
+                if (method.equals(Method.GET)) {
+                    int num = GetNumParameter(session.getParameters(), 0);
+                    if (num == -999 || num < 0 || num >= device.inputs) return newFixedLengthResponse(Response.Status.BAD_REQUEST, "text/plain", "Invalid num");
+                    Boolean level = mSwInputHandler != null ? mSwInputHandler.getLevel(num) : null;
+                    jsonResponse.put("success", true);
+                    // state stays null until the first edge after app start
+                    jsonResponse.put("state", level == null ? JSONObject.NULL : level);
+                    jsonResponse.put("mode", mSwInputHandler != null ? mSwInputHandler.getMode(num) : 0);
                 } else {
                     jsonResponse.put("success", false);
                     jsonResponse.put("error", "Invalid request method");

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/MainActivity.kt
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/MainActivity.kt
@@ -67,6 +67,7 @@ import me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mMediaHelper
 import me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mScreenSaverManager
 import me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mSharedPreferences
 import me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mShellyElevateJavascriptInterface
+import me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mSwInputHandler
 import me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mSwipeHelper
 import me.rapierxbox.shellyelevatev2.databinding.MainActivityBinding
 import me.rapierxbox.shellyelevatev2.helper.ServiceHelper
@@ -847,9 +848,8 @@ class MainActivity : ComponentActivity() {
                 }
                 return true
             }
-            // 141/142: physical switch inputs, edge-triggered on release.
-            141 -> { if (event.action == KeyEvent.ACTION_UP) switchInput(0, true); return true }
-            142 -> { if (event.action == KeyEvent.ACTION_UP) switchInput(1, true); return true }
+            // 141/142: physical sw inputs, handled centrally so every activity shares one path
+            141, 142 -> { mSwInputHandler?.onKeyEvent(event); return true }
 
             // 131..134: capacitive Shelly buttons 0..3; same press-type handling as power.
             131 -> {
@@ -893,13 +893,6 @@ class MainActivity : ComponentActivity() {
 
             else -> return false
         }
-    }
-
-    private fun switchInput(i: Int, state: Boolean) {
-        lifecycleScope.launch(Dispatchers.IO) {
-            mMQTTServer.publishSwitch(i, state)
-        }
-        mShellyElevateJavascriptInterface.onButtonPressed(100 + i)
     }
 
     private fun toggleMappedRelay(buttonId: Int) {

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/SettingsActivity.kt
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/SettingsActivity.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
+import android.view.KeyEvent
 import android.view.Menu
 import android.view.View
 import android.view.inputmethod.EditorInfo
@@ -40,6 +41,7 @@ import me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mDeviceHelper
 import me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mHttpServer
 import me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mScreenSaverManager
 import me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mSharedPreferences
+import me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mSwInputHandler
 import me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mSwipeHelper
 import me.rapierxbox.shellyelevatev2.databinding.SettingsActivityBinding
 import me.rapierxbox.shellyelevatev2.helper.ServiceHelper
@@ -70,4 +72,8 @@ class SettingsActivity : AppCompatActivity() {
         onBackPressedDispatcher.onBackPressed()
         return true
     }
+
+    // sw terminal edges must keep working while the settings screen holds focus
+    override fun dispatchKeyEvent(event: KeyEvent): Boolean =
+        (mSwInputHandler?.onKeyEvent(event) == true) || super.dispatchKeyEvent(event)
 }

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/SettingsFragment.kt
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/SettingsFragment.kt
@@ -123,6 +123,7 @@ class SettingsFragment : Fragment() {
 
         binding.screenSaverType.adapter = getScreenSaverSpinnerAdapter()
         binding.sleepOptimizationLevel.adapter = getSleepOptimizationSpinnerAdapter()
+        binding.swInputMode.adapter = getSwInputModeSpinnerAdapter()
 
         buildBinder()
         binder.loadAll()
@@ -271,6 +272,7 @@ class SettingsFragment : Fragment() {
         hasProximitySensor = device.hasProximitySensor
         val defaultClientId = "shellyelevate-" + UUID.randomUUID().toString().replace("-".toRegex(), "").substring(2, 6)
         val hasButtonRelayCapability = device.buttons > 0 && device.relays > 0
+        val hasSwInput = device.inputs > 0
 
         binder = SettingsBinder(mSharedPreferences).apply {
             +SwitchPref(binding.liteMode, SP_LITE_MODE, false)
@@ -299,6 +301,12 @@ class SettingsFragment : Fragment() {
             +SwitchPref(binding.switchOnSwipe, SP_SWITCH_ON_SWIPE, true)
             +SwitchPref(binding.powerButtonAutoReboot, SP_POWER_BUTTON_AUTO_REBOOT, true)
             +SwitchPref(binding.mediaEnabled, SP_MEDIA_ENABLED, false)
+
+            if (hasSwInput) {
+                // ui edits input 0; every current model has at most one sw input
+                +SpinnerPref(binding.swInputMode, String.format(Locale.US, SP_SW_INPUT_MODE_FORMAT, 0), SW_INPUT_MODE_BUTTON)
+                +SwitchPref(binding.swInputInvert, String.format(Locale.US, SP_SW_INPUT_INVERT_FORMAT, 0), false)
+            }
 
             +SwitchPref(binding.automaticBrightness, SP_AUTOMATIC_BRIGHTNESS, true)
             visibleWhenNot(binding.automaticBrightness, binding.brightnessSettingLayout)
@@ -355,6 +363,36 @@ class SettingsFragment : Fragment() {
         } else {
             binding.buttonRelayMappingLayout.isVisible = false
         }
+
+        binding.swInputModeLayout.isVisible = hasSwInput
+        binding.swInputInvert.isVisible = hasSwInput
+        binding.swInputModeHint.isVisible = hasSwInput
+        if (hasSwInput) {
+            setupSwInputRelaySpinner(device.relays)
+        } else {
+            binding.swInputRelayLayout.isVisible = false
+        }
+    }
+
+    private fun setupSwInputRelaySpinner(relayCount: Int) {
+        val options = mutableListOf(getString(R.string.button_relay_none))
+        for (i in 0 until relayCount) options.add(getString(R.string.button_relay_relay_label, i))
+        val adapter = ArrayAdapter(requireContext(), android.R.layout.simple_spinner_item, options)
+        adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+        binding.swInputRelay.adapter = adapter
+        // Stored value: -1 = None (position 0), 0 = Relay 0 (position 1), etc.
+        val storedRelay = mSharedPreferences.getInt(String.format(Locale.US, SP_SW_INPUT_RELAY_MAP_FORMAT, 0), 0)
+        binding.swInputRelay.setSelection((storedRelay + 1).coerceIn(0, options.size - 1))
+
+        // the relay row only applies while the input actually drives a relay
+        binding.swInputMode.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+            override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
+                binding.swInputRelayLayout.isVisible = relayCount > 0 && position != SW_INPUT_MODE_DETACHED
+            }
+            override fun onNothingSelected(parent: AdapterView<*>?) {}
+        }
+        val storedMode = mSharedPreferences.getInt(String.format(Locale.US, SP_SW_INPUT_MODE_FORMAT, 0), SW_INPUT_MODE_BUTTON)
+        binding.swInputRelayLayout.isVisible = relayCount > 0 && storedMode != SW_INPUT_MODE_DETACHED
     }
 
     private fun loadInlineValues() {
@@ -765,6 +803,11 @@ class SettingsFragment : Fragment() {
                 for (i in 0 until device.buttons.coerceAtMost(4))
                     putInt(String.format(Locale.US, SP_BUTTON_RELAY_MAP_FORMAT, i), spinners[i].selectedItemPosition - 1)
             }
+
+            // SW input relay target; spinner position 0 = None = -1
+            if (device.inputs > 0) {
+                putInt(String.format(Locale.US, SP_SW_INPUT_RELAY_MAP_FORMAT, 0), binding.swInputRelay.selectedItemPosition - 1)
+            }
         }
 
         // http server lifecycle is owned by the application settings receiver
@@ -787,6 +830,13 @@ class SettingsFragment : Fragment() {
     fun getSleepOptimizationSpinnerAdapter(): ArrayAdapter<CharSequence> {
         val ctx = ShellyElevateApplication.mApplicationContext
         val adapter = ArrayAdapter.createFromResource(ctx, R.array.sleep_optimization_levels, android.R.layout.simple_spinner_item)
+        adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+        return adapter
+    }
+
+    fun getSwInputModeSpinnerAdapter(): ArrayAdapter<CharSequence> {
+        val ctx = ShellyElevateApplication.mApplicationContext
+        val adapter = ArrayAdapter.createFromResource(ctx, R.array.sw_input_modes, android.R.layout.simple_spinner_item)
         adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
         return adapter
     }

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/ShellyElevateApplication.java
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/ShellyElevateApplication.java
@@ -28,6 +28,7 @@ import me.rapierxbox.shellyelevatev2.helper.MediaHelper;
 import me.rapierxbox.shellyelevatev2.helper.NightModeManager;
 import me.rapierxbox.shellyelevatev2.helper.PowerOptimizer;
 import me.rapierxbox.shellyelevatev2.helper.ScreenManager;
+import me.rapierxbox.shellyelevatev2.helper.SwInputHandler;
 import me.rapierxbox.shellyelevatev2.helper.SwipeHelper;
 import me.rapierxbox.shellyelevatev2.mqtt.MQTTServer;
 import me.rapierxbox.shellyelevatev2.screensavers.ScreenSaverManager;
@@ -42,6 +43,7 @@ public class ShellyElevateApplication extends Application {
     public static HttpServer mHttpServer;
 
     public static DeviceHelper mDeviceHelper;
+    public static SwInputHandler mSwInputHandler;
     public static DeviceSensorManager mDeviceSensorManager;
     public static SwipeHelper mSwipeHelper;
     public static ShellyElevateJavascriptInterface mShellyElevateJavascriptInterface;
@@ -105,6 +107,8 @@ public class ShellyElevateApplication extends Application {
             Log.i("ShellyElevateApplication", "Device: " + deviceModel.sku);
 
             mDeviceHelper = new DeviceHelper();
+            // built before DeviceSensorManager so native input events never hit a null handler
+            mSwInputHandler = new SwInputHandler();
             StesProtocolHandler.init();
             mScreenSaverManager = new ScreenSaverManager(this);
             mScreenManager = new ScreenManager(this);
@@ -264,6 +268,7 @@ public class ShellyElevateApplication extends Application {
     public void onTerminate() {
         mHttpServer.onDestroy();
         mDeviceSensorManager.onDestroy();
+        if (mSwInputHandler != null) mSwInputHandler.onDestroy();
 
         mScreenSaverManager.stopScreenSaver();
         mScreenSaverManager.onDestroy();

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/helper/DeviceSensorManager.java
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/helper/DeviceSensorManager.java
@@ -5,6 +5,7 @@ import static me.rapierxbox.shellyelevatev2.Constants.INTENT_LIGHT_UPDATED;
 import static me.rapierxbox.shellyelevatev2.Constants.INTENT_PROXIMITY_KEY;
 import static me.rapierxbox.shellyelevatev2.Constants.INTENT_PROXIMITY_UPDATED;
 import static me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mMQTTServer;
+import static me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mSwInputHandler;
 
 import android.content.Context;
 import android.content.Intent;
@@ -193,6 +194,12 @@ public class DeviceSensorManager implements SensorEventListener {
     }
 
     private void handleNativeKeyEvent(int keyCode, int action, int repeatCount) {
+        // 87/88 = key_f11/key_f12: rising/falling edge pulses of the sw
+        // terminal; this path stays alive regardless of which activity holds focus
+        if (SwInputHandler.isNativeSwInputCode(keyCode)) {
+            if (mSwInputHandler != null) mSwInputHandler.onNativeKey(keyCode, action);
+            return;
+        }
         // 63 = key_f5 (near), 64 = key_f6 (far)
         if (action == 1) { // down
             if (keyCode == 63) onGpioProximityEvent(true);
@@ -279,7 +286,21 @@ public class DeviceSensorManager implements SensorEventListener {
     // toggle the value back.
     private void handleProximityKeyLine(String line) {
         String normalized = line.toUpperCase(Locale.US);
-        if (!normalized.contains(" DOWN")) {
+        boolean isDown = normalized.contains(" DOWN");
+
+        // f11/f12 are rising/falling edge pulses of the sw terminal; like the
+        // proximity keys, only the pulse's down line carries the transition
+        if (normalized.contains("KEY_F11") || normalized.contains("KEY_F12")) {
+            if (mSwInputHandler != null && isDown) {
+                int code = normalized.contains("KEY_F11")
+                        ? SwInputStateMachine.LINUX_KEY_SW_RISING
+                        : SwInputStateMachine.LINUX_KEY_SW_FALLING;
+                mSwInputHandler.onNativeKey(code, 1);
+            }
+            return;
+        }
+
+        if (!isDown) {
             return;
         }
 

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/helper/SwInputHandler.java
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/helper/SwInputHandler.java
@@ -1,0 +1,247 @@
+package me.rapierxbox.shellyelevatev2.helper;
+
+import static me.rapierxbox.shellyelevatev2.Constants.INTENT_SETTINGS_CHANGED;
+import static me.rapierxbox.shellyelevatev2.Constants.SP_SW_INPUT_INVERT_FORMAT;
+import static me.rapierxbox.shellyelevatev2.Constants.SP_SW_INPUT_MODE_FORMAT;
+import static me.rapierxbox.shellyelevatev2.Constants.SP_SW_INPUT_RELAY_MAP_FORMAT;
+import static me.rapierxbox.shellyelevatev2.Constants.SW_INPUT_MODE_BUTTON;
+import static me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mApplicationContext;
+import static me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mDeviceHelper;
+import static me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mMQTTServer;
+import static me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mSharedPreferences;
+import static me.rapierxbox.shellyelevatev2.ShellyElevateApplication.mShellyElevateJavascriptInterface;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.content.SharedPreferences;
+import android.os.Handler;
+import android.os.Looper;
+import android.os.SystemClock;
+import android.util.Log;
+import android.view.KeyEvent;
+
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+
+import java.util.Locale;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import me.rapierxbox.shellyelevatev2.DeviceModel;
+
+// Single owner of the SW terminal input. The hardware reports each contact
+// transition as a short down+up key pulse whose KEYCODE encodes the direction:
+// 141/KEY_F11 = rising edge, 142/KEY_F12 = falling edge of the one SW terminal
+// (verified on the X1i; every supported model declares a single input). Edges
+// arrive via both the focused activity's KeyEvents and the native input
+// monitor; SwInputStateMachine drops the duplicate delivery and applies the
+// configured input mode.
+public class SwInputHandler {
+    private static final String TAG = "SwInputHandler";
+
+    // all current hardware has exactly one sw terminal
+    private static final int SW_INPUT_INDEX = 0;
+
+    // js interface reports sw inputs as button ids 100+i (pre-existing contract)
+    private static final int JS_BUTTON_ID_BASE = 100;
+
+    private final DeviceModel device;
+    private final SwInputStateMachine stateMachine;
+    private final ButtonPressDetector[] pressDetectors;
+    private final int[] configuredModes;
+    private final boolean[] configuredInverts;
+    private final Handler mainHandler = new Handler(Looper.getMainLooper());
+    // relay sysfs writes and mqtt publishes stay off the main thread; a single
+    // thread keeps press/release ordering intact
+    private final ExecutorService ioExecutor = Executors.newSingleThreadExecutor();
+    private final BroadcastReceiver settingsReceiver;
+
+    public SwInputHandler() {
+        device = DeviceModel.getReportedDevice();
+        stateMachine = new SwInputStateMachine(device.inputs, new StateMachineActions());
+        pressDetectors = new ButtonPressDetector[device.inputs];
+        configuredModes = new int[device.inputs];
+        configuredInverts = new boolean[device.inputs];
+        for (int i = 0; i < device.inputs; i++) {
+            pressDetectors[i] = new ButtonPressDetector(JS_BUTTON_ID_BASE + i, (buttonId, pressType) ->
+                    ioExecutor.execute(() -> {
+                        if (mMQTTServer != null && mMQTTServer.shouldSend()) {
+                            mMQTTServer.publishButton(buttonId, pressType);
+                        }
+                    }));
+        }
+
+        seedDefaults();
+        for (int i = 0; i < device.inputs; i++) {
+            configuredModes[i] = readMode(i);
+            configuredInverts[i] = readInvert(i);
+            stateMachine.configure(i, configuredModes[i], configuredInverts[i]);
+        }
+
+        settingsReceiver = new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context context, Intent intent) {
+                applyConfigChanges();
+            }
+        };
+        LocalBroadcastManager.getInstance(mApplicationContext)
+                .registerReceiver(settingsReceiver, new IntentFilter(INTENT_SETTINGS_CHANGED));
+    }
+
+    /** Handles sw input keycodes; returns false for anything else so callers can pass those on. */
+    public boolean onKeyEvent(KeyEvent event) {
+        Boolean swLevel = SwInputStateMachine.levelForAndroidKey(event.getKeyCode());
+        if (swLevel == null) return false;
+        // the level is coded in the keycode, so only the pulse's ACTION_DOWN
+        // carries a transition; the pulse tail (up) and auto repeats are
+        // swallowed, as is everything on models without an input, so sw
+        // keycodes never leak into the webview
+        if (event.getAction() == KeyEvent.ACTION_DOWN && event.getRepeatCount() == 0
+                && SW_INPUT_INDEX < device.inputs) {
+            submitEdge(SW_INPUT_INDEX, swLevel);
+        }
+        return true;
+    }
+
+    /** Intake for the native input monitor. action: 0=UP, 1=DOWN, 2=REPEAT. */
+    public void onNativeKey(int linuxCode, int action) {
+        Boolean swLevel = SwInputStateMachine.levelForLinuxKey(linuxCode);
+        if (swLevel == null) return;
+        // only the pulse's down event carries the transition (see onKeyEvent)
+        if (action == 1 && SW_INPUT_INDEX < device.inputs) {
+            submitEdge(SW_INPUT_INDEX, swLevel);
+        }
+    }
+
+    /** True while the linux code is a sw terminal edge pulse the handler consumes. */
+    public static boolean isNativeSwInputCode(int linuxCode) {
+        return SwInputStateMachine.levelForLinuxKey(linuxCode) != null;
+    }
+
+    /** Logical contact level of input i, null until the first edge after start. */
+    public Boolean getLevel(int input) {
+        return stateMachine.getLevel(input);
+    }
+
+    public int getMode(int input) {
+        return stateMachine.getMode(input);
+    }
+
+    public int getInputCount() {
+        return device.inputs;
+    }
+
+    private void submitEdge(int input, boolean level) {
+        // timestamp at ingestion; processing is serialized on the main looper so
+        // native-thread and ui-thread deliveries cannot race the state machine
+        final long nowMs = SystemClock.elapsedRealtime();
+        mainHandler.post(() -> {
+            boolean accepted = stateMachine.onEdge(input, level, nowMs);
+            Log.d(TAG, "sw input " + input + (level ? " rise" : " fall") + (accepted ? " accepted" : " dropped"));
+        });
+    }
+
+    private void applyConfigChanges() {
+        for (int i = 0; i < device.inputs; i++) {
+            int mode = readMode(i);
+            boolean invert = readInvert(i);
+            if (mode != configuredModes[i] || invert != configuredInverts[i]) {
+                configuredModes[i] = mode;
+                configuredInverts[i] = invert;
+                stateMachine.configure(i, mode, invert);
+                // a stale mid-press level must not suppress the next real edge
+                stateMachine.reset(i);
+                Log.i(TAG, "sw input " + i + " reconfigured: mode=" + mode + " invert=" + invert);
+            }
+        }
+    }
+
+    // seed the keys so GET /settings exposes them before the first ui save
+    private void seedDefaults() {
+        SharedPreferences.Editor editor = null;
+        for (int i = 0; i < device.inputs; i++) {
+            if (!mSharedPreferences.contains(formatKey(SP_SW_INPUT_MODE_FORMAT, i))) {
+                if (editor == null) editor = mSharedPreferences.edit();
+                editor.putInt(formatKey(SP_SW_INPUT_MODE_FORMAT, i), SW_INPUT_MODE_BUTTON);
+            }
+            if (!mSharedPreferences.contains(formatKey(SP_SW_INPUT_RELAY_MAP_FORMAT, i))) {
+                if (editor == null) editor = mSharedPreferences.edit();
+                editor.putInt(formatKey(SP_SW_INPUT_RELAY_MAP_FORMAT, i), 0);
+            }
+            if (!mSharedPreferences.contains(formatKey(SP_SW_INPUT_INVERT_FORMAT, i))) {
+                if (editor == null) editor = mSharedPreferences.edit();
+                editor.putBoolean(formatKey(SP_SW_INPUT_INVERT_FORMAT, i), false);
+            }
+        }
+        if (editor != null) editor.apply();
+    }
+
+    private int readMode(int input) {
+        return mSharedPreferences.getInt(formatKey(SP_SW_INPUT_MODE_FORMAT, input), SW_INPUT_MODE_BUTTON);
+    }
+
+    private boolean readInvert(int input) {
+        return mSharedPreferences.getBoolean(formatKey(SP_SW_INPUT_INVERT_FORMAT, input), false);
+    }
+
+    private static String formatKey(String format, int input) {
+        return String.format(Locale.US, format, input);
+    }
+
+    public void onDestroy() {
+        LocalBroadcastManager.getInstance(mApplicationContext).unregisterReceiver(settingsReceiver);
+        ioExecutor.shutdown();
+    }
+
+    private class StateMachineActions implements SwInputStateMachine.Actions {
+        @Override
+        public void publishLevel(int input, boolean pressed) {
+            ioExecutor.execute(() -> {
+                if (mMQTTServer != null && mMQTTServer.shouldSend()) {
+                    mMQTTServer.publishSwitch(input, pressed);
+                }
+            });
+        }
+
+        @Override
+        public void toggleRelay(int input) {
+            ioExecutor.execute(() -> {
+                DeviceHelper deviceHelper = mDeviceHelper;
+                int relayIndex = relayIndexFor(input);
+                if (deviceHelper == null || relayIndex < 0) return;
+                deviceHelper.setRelay(relayIndex, !deviceHelper.getRelay(relayIndex));
+            });
+        }
+
+        @Override
+        public void setRelayLevel(int input, boolean on) {
+            ioExecutor.execute(() -> {
+                DeviceHelper deviceHelper = mDeviceHelper;
+                int relayIndex = relayIndexFor(input);
+                if (deviceHelper == null || relayIndex < 0) return;
+                deviceHelper.setRelay(relayIndex, on);
+            });
+        }
+
+        @Override
+        public void fireJsEvent(int input) {
+            if (mShellyElevateJavascriptInterface != null) {
+                mShellyElevateJavascriptInterface.onButtonPressed(JS_BUTTON_ID_BASE + input);
+            }
+        }
+
+        @Override
+        public void buttonEdge(int input, boolean down) {
+            if (down) pressDetectors[input].onPressDown();
+            else pressDetectors[input].onPressUp();
+        }
+
+        // read live so relay remapping applies without a reconfigure round trip
+        private int relayIndexFor(int input) {
+            int relayIndex = mSharedPreferences.getInt(formatKey(SP_SW_INPUT_RELAY_MAP_FORMAT, input), 0);
+            if (relayIndex < 0 || relayIndex >= device.relays) return -1;
+            return relayIndex;
+        }
+    }
+}

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/helper/SwInputStateMachine.java
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/helper/SwInputStateMachine.java
@@ -1,0 +1,133 @@
+package me.rapierxbox.shellyelevatev2.helper;
+
+import me.rapierxbox.shellyelevatev2.Constants;
+
+// Mode logic for the SW terminal input, mirroring the stock firmware input
+// types: detached (report only), button (momentary, press toggles), switch-edge
+// (every level change toggles) and switch-follow (relay tracks the contact
+// position). onEdge() consumes contact LEVELS: the hardware reports each
+// transition as a short key pulse whose keycode encodes the direction
+// (141/KEY_F11 = rising, 142/KEY_F12 = falling; verified on the X1i), decoded
+// by the static keymap helpers below. Pure java so it stays unit testable;
+// all android wiring lives in SwInputHandler.
+public class SwInputStateMachine {
+    // the native monitor and the activity KeyEvent path both deliver the same
+    // physical pulse a few ms apart; a same-level event inside this window is
+    // that second delivery. A same-level pulse AFTER the window is treated as a
+    // real repeat (possible in multi-way taster circuits) and processed again.
+    // Opposite-level events are always real - the direction is keycode-coded
+    // and the OEM layer already debounces the contacts.
+    public static final long DUPLICATE_WINDOW_MS = 300;
+
+    // android keycodes and raw linux codes carrying the sw terminal edges
+    public static final int ANDROID_KEY_SW_RISING = 141;  // KEYCODE_F11
+    public static final int ANDROID_KEY_SW_FALLING = 142; // KEYCODE_F12
+    public static final int LINUX_KEY_SW_RISING = 87;     // KEY_F11
+    public static final int LINUX_KEY_SW_FALLING = 88;    // KEY_F12
+
+    /** Contact level carried by an android sw keycode, or null for other keys. */
+    public static Boolean levelForAndroidKey(int keyCode) {
+        if (keyCode == ANDROID_KEY_SW_RISING) return Boolean.TRUE;
+        if (keyCode == ANDROID_KEY_SW_FALLING) return Boolean.FALSE;
+        return null;
+    }
+
+    /** Contact level carried by a raw linux sw key code, or null for other keys. */
+    public static Boolean levelForLinuxKey(int linuxCode) {
+        if (linuxCode == LINUX_KEY_SW_RISING) return Boolean.TRUE;
+        if (linuxCode == LINUX_KEY_SW_FALLING) return Boolean.FALSE;
+        return null;
+    }
+
+    public interface Actions {
+        void publishLevel(int input, boolean pressed);
+        void toggleRelay(int input);
+        void setRelayLevel(int input, boolean on);
+        void fireJsEvent(int input);
+        void buttonEdge(int input, boolean down);
+    }
+
+    private final Actions actions;
+    private final int[] modes;
+    private final boolean[] inverts;
+    private final Boolean[] levels;
+    private final long[] lastEdgeAtMs;
+
+    public SwInputStateMachine(int inputCount, Actions actions) {
+        this.actions = actions;
+        modes = new int[inputCount];
+        inverts = new boolean[inputCount];
+        levels = new Boolean[inputCount];
+        lastEdgeAtMs = new long[inputCount];
+        for (int i = 0; i < inputCount; i++) modes[i] = Constants.SW_INPUT_MODE_BUTTON;
+    }
+
+    public int getInputCount() {
+        return modes.length;
+    }
+
+    public synchronized void configure(int input, int mode, boolean invert) {
+        if (!validInput(input)) return;
+        modes[input] = mode;
+        inverts[input] = invert;
+    }
+
+    /** Clears the tracked level so the next event is never dropped as a duplicate. */
+    public synchronized void reset(int input) {
+        if (!validInput(input)) return;
+        levels[input] = null;
+        lastEdgeAtMs[input] = 0;
+    }
+
+    /** Logical contact level, null until the first accepted event. */
+    public synchronized Boolean getLevel(int input) {
+        return validInput(input) ? levels[input] : null;
+    }
+
+    public synchronized int getMode(int input) {
+        return validInput(input) ? modes[input] : Constants.SW_INPUT_MODE_DETACHED;
+    }
+
+    /**
+     * Feed a contact level reported by the hardware. Returns true when the
+     * event was accepted; the double delivery of one pulse is dropped.
+     */
+    public synchronized boolean onEdge(int input, boolean rawLevel, long nowMs) {
+        if (!validInput(input)) return false;
+        boolean logical = rawLevel ^ inverts[input];
+        Boolean level = levels[input];
+        if (level != null && level == logical && nowMs - lastEdgeAtMs[input] < DUPLICATE_WINDOW_MS) {
+            return false;
+        }
+        levels[input] = logical;
+        lastEdgeAtMs[input] = nowMs;
+
+        actions.publishLevel(input, logical);
+        switch (modes[input]) {
+            case Constants.SW_INPUT_MODE_BUTTON:
+                actions.buttonEdge(input, logical);
+                if (logical) {
+                    actions.toggleRelay(input);
+                    actions.fireJsEvent(input);
+                }
+                break;
+            case Constants.SW_INPUT_MODE_SWITCH_EDGE:
+                actions.toggleRelay(input);
+                actions.fireJsEvent(input);
+                break;
+            case Constants.SW_INPUT_MODE_SWITCH_FOLLOW:
+                actions.setRelayLevel(input, logical);
+                actions.fireJsEvent(input);
+                break;
+            default:
+                // detached: report only; js event once per press like before
+                if (logical) actions.fireJsEvent(input);
+                break;
+        }
+        return true;
+    }
+
+    private boolean validInput(int input) {
+        return input >= 0 && input < modes.length;
+    }
+}

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/mqtt/MQTTServer.java
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/mqtt/MQTTServer.java
@@ -367,6 +367,14 @@ public class MQTTServer {
                     for (int num = 0; num < DeviceModel.getReportedDevice().relays; num++) {
                         publishRelay(num, mDeviceHelper.getRelay(num));
                     }
+                    // re-sync the input binary_sensors after a reconnect; the level
+                    // stays unknown until the first edge after app start
+                    if (mSwInputHandler != null) {
+                        for (int num = 0; num < DeviceModel.getReportedDevice().inputs; num++) {
+                            Boolean level = mSwInputHandler.getLevel(num);
+                            if (level != null) publishSwitch(num, level);
+                        }
+                    }
                 }, 100, TimeUnit.MILLISECONDS);
 
                 scheduler.schedule(() -> {

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/mqtt/MqttDiscoveryConfigBuilder.java
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/mqtt/MqttDiscoveryConfigBuilder.java
@@ -9,6 +9,8 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.util.Locale;
+
 import me.rapierxbox.shellyelevatev2.BuildConfig;
 import me.rapierxbox.shellyelevatev2.DeviceModel;
 import me.rapierxbox.shellyelevatev2.helper.ThermalZoneReader;
@@ -134,6 +136,15 @@ class MqttDiscoveryConfigBuilder {
             sw.put("unique_id", clientId + "_switch" + suffix);
             sw.put("object_id", "shelly_walldisplay_" + clientId + "_switch" + suffix);
             components.put(clientId + "_switch" + suffix, sw);
+
+            // in button mode the input also emits press gestures on button/10x,
+            // mirroring the touch button event entities
+            int mode = prefs.getInt(String.format(Locale.US, SP_SW_INPUT_MODE_FORMAT, num), SW_INPUT_MODE_BUTTON);
+            if (mode == SW_INPUT_MODE_BUTTON) {
+                String eventTopic = parseTopic(MQTT_TOPIC_BUTTON_STATE) + "/" + (100 + num);
+                String eventId = clientId + "_switch" + suffix + "_events";
+                components.put(eventId, buttonEventConfig(("Switch" + nameTrailer + " Events").trim(), eventTopic, eventId));
+            }
         }
     }
 

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/screensavers/activities/DigitalClockAndDateScreenSaverActivity.kt
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/screensavers/activities/DigitalClockAndDateScreenSaverActivity.kt
@@ -8,6 +8,7 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.os.Bundle
 import android.util.Log
+import android.view.KeyEvent
 import androidx.core.view.isVisible
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import me.rapierxbox.shellyelevatev2.Constants.INTENT_END_SCREENSAVER
@@ -80,4 +81,8 @@ class DigitalClockAndDateScreenSaverActivity : Activity() {
         LocalBroadcastManager.getInstance(this).unregisterReceiver(mEndScreenSaverReciever)
         binding = null
     }
+
+    // sw terminal edges must keep working while the screensaver holds focus
+    override fun dispatchKeyEvent(event: KeyEvent): Boolean =
+        (ShellyElevateApplication.mSwInputHandler?.onKeyEvent(event) == true) || super.dispatchKeyEvent(event)
 }

--- a/app/src/main/res/layout/settings_fragment.xml
+++ b/app/src/main/res/layout/settings_fragment.xml
@@ -218,6 +218,76 @@
                 android:textSize="18sp"
                 tools:ignore="UseSwitchCompatOrMaterialXml" />
 
+            <!-- SW terminal input -->
+            <LinearLayout
+                android:id="@+id/swInputModeLayout"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_vertical"
+                    android:layout_weight="1"
+                    android:labelFor="@id/swInputMode"
+                    android:text="@string/sw_input_mode_title"
+                    android:textSize="18sp" />
+
+                <Spinner
+                    android:id="@+id/swInputMode"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:spinnerMode="dialog" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/swInputRelayLayout"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="48dp"
+                android:layout_marginTop="8dp"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_vertical"
+                    android:layout_weight="1"
+                    android:labelFor="@id/swInputRelay"
+                    android:text="@string/sw_input_relay_title"
+                    android:textSize="18sp" />
+
+                <Spinner
+                    android:id="@+id/swInputRelay"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:spinnerMode="dialog" />
+
+            </LinearLayout>
+
+            <com.google.android.material.materialswitch.MaterialSwitch
+                android:id="@+id/swInputInvert"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="48dp"
+                android:layout_marginTop="8dp"
+                android:text="@string/sw_input_invert"
+                android:textSize="18sp"
+                tools:ignore="UseSwitchCompatOrMaterialXml" />
+
+            <TextView
+                android:id="@+id/swInputModeHint"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="48dp"
+                android:layout_marginTop="4dp"
+                android:text="@string/sw_input_mode_hint"
+                android:textSize="14sp"
+                android:textStyle="italic" />
+
             <!-- Button-to-Relay Mapping -->
             <com.google.android.material.materialswitch.MaterialSwitch
                 android:id="@+id/buttonRelayEnabled"

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -6,4 +6,12 @@
         <item>@string/sleep_opt_standard</item>
         <item>@string/sleep_opt_aggressive</item>
     </string-array>
+
+    <!-- order must match the SW_INPUT_MODE_* int constants -->
+    <string-array name="sw_input_modes">
+        <item>@string/sw_input_mode_detached</item>
+        <item>@string/sw_input_mode_button</item>
+        <item>@string/sw_input_mode_switch_edge</item>
+        <item>@string/sw_input_mode_switch_follow</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -111,6 +111,14 @@
     <string name="button_relay_button_label">Button %1$d</string>
     <string name="button_relay_none">None</string>
     <string name="button_relay_relay_label">Relay %1$d</string>
+    <string name="sw_input_mode_title">External switch input (SW)</string>
+    <string name="sw_input_mode_hint">Behavior of the SW terminal on the mounting base. Button toggles the relay on each press, the switch modes react to the contact position, detached only reports to MQTT/JS.</string>
+    <string name="sw_input_mode_detached">Detached (report only)</string>
+    <string name="sw_input_mode_button">Button: press toggles relay</string>
+    <string name="sw_input_mode_switch_edge">Switch: every flip toggles relay</string>
+    <string name="sw_input_mode_switch_follow">Switch: relay follows position</string>
+    <string name="sw_input_relay_title">Controlled relay</string>
+    <string name="sw_input_invert">Invert input</string>
     <string name="bt_proxy_enabled">Bluetooth Proxy (ESPHome API)</string>
     <string name="bt_proxy_name">Device Name</string>
     <string name="bt_proxy_name_hint">ShellyElevate</string>

--- a/app/src/test/java/me/rapierxbox/shellyelevatev2/helper/SwInputStateMachineTest.java
+++ b/app/src/test/java/me/rapierxbox/shellyelevatev2/helper/SwInputStateMachineTest.java
@@ -1,0 +1,231 @@
+package me.rapierxbox.shellyelevatev2.helper;
+
+import static me.rapierxbox.shellyelevatev2.Constants.SW_INPUT_MODE_BUTTON;
+import static me.rapierxbox.shellyelevatev2.Constants.SW_INPUT_MODE_DETACHED;
+import static me.rapierxbox.shellyelevatev2.Constants.SW_INPUT_MODE_SWITCH_EDGE;
+import static me.rapierxbox.shellyelevatev2.Constants.SW_INPUT_MODE_SWITCH_FOLLOW;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SwInputStateMachineTest {
+
+    private static class RecordingActions implements SwInputStateMachine.Actions {
+        final List<String> events = new ArrayList<>();
+
+        @Override public void publishLevel(int input, boolean pressed) { events.add("level:" + input + ":" + pressed); }
+        @Override public void toggleRelay(int input) { events.add("toggle:" + input); }
+        @Override public void setRelayLevel(int input, boolean on) { events.add("set:" + input + ":" + on); }
+        @Override public void fireJsEvent(int input) { events.add("js:" + input); }
+        @Override public void buttonEdge(int input, boolean down) { events.add("btn:" + input + ":" + (down ? "down" : "up")); }
+
+        long count(String prefix) {
+            return events.stream().filter(e -> e.startsWith(prefix)).count();
+        }
+    }
+
+    private RecordingActions actions;
+    private SwInputStateMachine machine;
+
+    @Before
+    public void setUp() {
+        actions = new RecordingActions();
+        machine = new SwInputStateMachine(2, actions);
+    }
+
+    // --- keymap: 141/KEY_F11 = rising edge, 142/KEY_F12 = falling edge ---
+
+    @Test
+    public void androidKeymapDecodesEdgeDirection() {
+        assertEquals(Boolean.TRUE, SwInputStateMachine.levelForAndroidKey(141));
+        assertEquals(Boolean.FALSE, SwInputStateMachine.levelForAndroidKey(142));
+        assertNull(SwInputStateMachine.levelForAndroidKey(131));
+        assertNull(SwInputStateMachine.levelForAndroidKey(140));
+    }
+
+    @Test
+    public void linuxKeymapDecodesEdgeDirection() {
+        assertEquals(Boolean.TRUE, SwInputStateMachine.levelForLinuxKey(87));
+        assertEquals(Boolean.FALSE, SwInputStateMachine.levelForLinuxKey(88));
+        assertNull(SwInputStateMachine.levelForLinuxKey(63));
+        assertNull(SwInputStateMachine.levelForLinuxKey(64));
+    }
+
+    // --- dedup: only same-level events inside the duplicate window are dropped ---
+
+    @Test
+    public void doubleDeliveryOfOnePulseDropped() {
+        assertTrue(machine.onEdge(0, true, 0));
+        // the second source delivers the same pulse a few ms later
+        assertFalse(machine.onEdge(0, true, 12));
+        assertEquals(1, actions.count("toggle:0"));
+        assertEquals(1, actions.count("level:0:"));
+    }
+
+    @Test
+    public void oppositeLevelAlwaysAcceptedEvenFast() {
+        machine.configure(0, SW_INPUT_MODE_SWITCH_EDGE, false);
+        assertTrue(machine.onEdge(0, true, 0));
+        // a genuine opposite transition right after must not be eaten; the
+        // direction is keycode-coded, so it cannot be delivery noise
+        assertTrue(machine.onEdge(0, false, 5));
+        assertEquals(2, actions.count("toggle:0"));
+        assertEquals(Boolean.FALSE, machine.getLevel(0));
+    }
+
+    @Test
+    public void sameLevelRepeatAfterWindowAcceptedAgain() {
+        machine.configure(0, SW_INPUT_MODE_SWITCH_EDGE, false);
+        assertTrue(machine.onEdge(0, true, 0));
+        // a repeated same-direction pulse after the window is a real press
+        // (possible in multi-way taster circuits) and must toggle again
+        assertTrue(machine.onEdge(0, true, SwInputStateMachine.DUPLICATE_WINDOW_MS + 50));
+        assertEquals(2, actions.count("toggle:0"));
+    }
+
+    // --- mode behavior on correct levels ---
+
+    @Test
+    public void detachedPublishesLevelsOnly() {
+        machine.configure(0, SW_INPUT_MODE_DETACHED, false);
+        assertTrue(machine.onEdge(0, true, 0));
+        assertTrue(machine.onEdge(0, false, 1000));
+        assertEquals(List.of("level:0:true", "js:0", "level:0:false"), actions.events);
+        assertEquals(0, actions.count("toggle:"));
+        assertEquals(0, actions.count("set:"));
+        assertEquals(0, actions.count("btn:"));
+    }
+
+    @Test
+    public void buttonTogglesOnRisingEdgeOnly() {
+        // button is the default mode
+        assertTrue(machine.onEdge(0, true, 0));
+        assertEquals(List.of("level:0:true", "btn:0:down", "toggle:0", "js:0"), actions.events);
+
+        actions.events.clear();
+        assertTrue(machine.onEdge(0, false, 1000));
+        assertEquals(List.of("level:0:false", "btn:0:up"), actions.events);
+    }
+
+    @Test
+    public void switchEdgeTogglesOnEveryLevelChange() {
+        machine.configure(0, SW_INPUT_MODE_SWITCH_EDGE, false);
+        assertTrue(machine.onEdge(0, true, 0));
+        assertTrue(machine.onEdge(0, false, 1000));
+        assertTrue(machine.onEdge(0, true, 2000));
+        assertEquals(3, actions.count("toggle:0"));
+        assertEquals(3, actions.count("js:0"));
+        assertTrue(actions.events.contains("level:0:true"));
+        assertTrue(actions.events.contains("level:0:false"));
+    }
+
+    @Test
+    public void switchFollowSetsRelayToLevel() {
+        machine.configure(0, SW_INPUT_MODE_SWITCH_FOLLOW, false);
+        assertTrue(machine.onEdge(0, true, 0));
+        assertTrue(machine.onEdge(0, false, 1000));
+        assertEquals(List.of("level:0:true", "set:0:true", "js:0", "level:0:false", "set:0:false", "js:0"), actions.events);
+        assertEquals(0, actions.count("toggle:"));
+    }
+
+    @Test
+    public void invertFlipsLogicalLevel() {
+        machine.configure(0, SW_INPUT_MODE_SWITCH_FOLLOW, true);
+        assertTrue(machine.onEdge(0, true, 0));
+        assertEquals(List.of("level:0:false", "set:0:false", "js:0"), actions.events);
+        assertEquals(Boolean.FALSE, machine.getLevel(0));
+    }
+
+    @Test
+    public void firstEventAlwaysAcceptedEvenFalling() {
+        assertNull(machine.getLevel(0));
+        assertTrue(machine.onEdge(0, false, 0));
+        assertEquals(List.of("level:0:false", "btn:0:up"), actions.events);
+        assertEquals(0, actions.count("toggle:"));
+    }
+
+    @Test
+    public void modeChangeWithResetAcceptsNextEvent() {
+        assertTrue(machine.onEdge(0, true, 0));
+        machine.configure(0, SW_INPUT_MODE_SWITCH_EDGE, false);
+        machine.reset(0);
+        // same level again right after a reset must not be treated as duplicate
+        assertTrue(machine.onEdge(0, true, 50));
+        assertEquals(SW_INPUT_MODE_SWITCH_EDGE, machine.getMode(0));
+    }
+
+    @Test
+    public void inputsAreIndependent() {
+        assertTrue(machine.onEdge(0, true, 0));
+        assertTrue(machine.onEdge(1, true, 5));
+        assertEquals(1, actions.count("toggle:0"));
+        assertEquals(1, actions.count("toggle:1"));
+    }
+
+    @Test
+    public void detachedFiresJsOncePerPress() {
+        machine.configure(0, SW_INPUT_MODE_DETACHED, false);
+        assertTrue(machine.onEdge(0, false, 0));
+        assertTrue(machine.onEdge(0, true, 1000));
+        assertTrue(machine.onEdge(0, false, 2000));
+        assertEquals(1, actions.count("js:0"));
+    }
+
+    @Test
+    public void invalidInputIndexRejected() {
+        assertFalse(machine.onEdge(5, true, 0));
+        assertFalse(machine.onEdge(-1, true, 0));
+        assertNull(machine.getLevel(5));
+        assertEquals(0, actions.events.size());
+    }
+
+    @Test
+    public void buttonModeIsDefault() {
+        assertEquals(SW_INPUT_MODE_BUTTON, machine.getMode(0));
+    }
+
+    // --- regression: the exact hardware trace from the X1i field test ---
+    // Two tasters in a multi-way (wechsel/kreuz) circuit: each press flips the
+    // line once, alternating direction. Every pulse is delivered twice (native
+    // monitor + activity KeyEvent) ~10ms apart. Five presses were observed:
+    // rise, fall, rise, fall, rise. The old code swallowed the falling pulses,
+    // toggling only every second press.
+
+    private void replayFieldTrace() {
+        long[] pressAt = {0, 1030, 1960, 2990, 3820};
+        boolean[] lvl = {true, false, true, false, true};
+        for (int i = 0; i < pressAt.length; i++) {
+            machine.onEdge(0, lvl[i], pressAt[i]);       // native delivery
+            machine.onEdge(0, lvl[i], pressAt[i] + 10);  // keyevent delivery of the same pulse
+        }
+    }
+
+    @Test
+    public void fieldTraceEdgeModeTogglesOnEveryPress() {
+        machine.configure(0, SW_INPUT_MODE_SWITCH_EDGE, false);
+        replayFieldTrace();
+        assertEquals(5, actions.count("toggle:0"));
+        assertEquals(5, actions.count("level:0:"));
+    }
+
+    @Test
+    public void fieldTraceButtonModeTogglesOnRisingPressesOnly() {
+        replayFieldTrace();
+        assertEquals(3, actions.count("toggle:0"));
+    }
+
+    @Test
+    public void fieldTraceFollowModeTracksLevel() {
+        machine.configure(0, SW_INPUT_MODE_SWITCH_FOLLOW, false);
+        replayFieldTrace();
+        assertEquals(List.of("set:0:true", "set:0:false", "set:0:true", "set:0:false", "set:0:true"),
+                actions.events.stream().filter(e -> e.startsWith("set:")).toList());
+    }
+}

--- a/docs/sw-input.md
+++ b/docs/sw-input.md
@@ -1,0 +1,108 @@
+# SW input (external switch / push-button)
+
+The mounting base has an SW screw terminal for an external wall switch or
+push-button. Stock firmware couples it to the relay with an "Input Type:
+Button/Switch" setting; ShellyElevate does the same, locally on the device —
+no MQTT broker or Home Assistant round-trip involved, and the input keeps
+working while the screensaver or the settings screen is open.
+
+## How the hardware reports the input
+
+The device does not deliver the SW contact as a held key. Each contact
+*transition* arrives as a short (~5 ms) down+up key pulse, and the keycode
+encodes the direction: keycode 141 (`KEY_F11`) = the line went active,
+keycode 142 (`KEY_F12`) = the line went inactive. Verified on a Wall Display
+X1i; every supported model has exactly one SW terminal. ShellyElevate decodes
+those pulses into a contact level and applies the configured mode to it.
+
+## Modes
+
+Set per input under Settings → "External switch input (SW)", or via the
+`swInputMode0` key in the settings API.
+
+| Value | Mode | Relay | Reported |
+|---|---|---|---|
+| 0 | Detached | never touched | PRESS/RELEASE per edge, JS event per press |
+| 1 | Button (default) | toggles on every press | PRESS/RELEASE + press gestures |
+| 2 | Switch, edge | toggles on every flip | PRESS/RELEASE per edge |
+| 3 | Switch, follow | tracks the contact position | PRESS/RELEASE per edge |
+
+- **Button** is for momentary push-buttons (tasters): the relay toggles the
+  moment the button is pressed. Gestures are published like the capacitive
+  buttons: `short`/`long`/`double`/`triple` on `shellyelevatev2/<id>/button/100`.
+- **Switch (edge)** is for toggle switches when the relay is also switched from
+  the dashboard or HA: every flip changes the relay state, no flip is wasted.
+- **Switch (follow)** forces the relay to the contact position on every change
+  (stock wording: "the position of the switch corresponds to the output").
+  Until the first flip after boot the relay and the switch can disagree — the
+  contact level is only known once it changes.
+- **Detached** is the behavior of previous ShellyElevate versions: events are
+  reported, the relay is not touched.
+
+## Which mode for which wiring
+
+- Push-buttons wired in parallel to SW (each press pulls the line active,
+  release lets it go): **Button**. Press toggles, hold duration drives the
+  long-press gesture.
+- Push-buttons reusing an existing multi-way circuit (Wechsel-/Kreuzschaltung),
+  where each press flips the line once and the direction alternates press to
+  press: **Switch — every flip toggles relay**. Every press toggles, regardless
+  of direction.
+- Maintained flip switches: **Switch — every flip toggles** (never a wasted
+  flip when the relay is also controlled from the display or HA) or
+  **Switch — relay follows position** for strict position coupling.
+
+## Settings keys
+
+| Key | Type | Default | Meaning |
+|---|---|---|---|
+| `swInputMode0` | int | `1` | see the mode table above |
+| `swInputRelayMap0` | int | `0` | relay index driven by the input, `-1` = none |
+| `swInputInvert0` | bool | `false` | invert the contact level (NC wiring) |
+
+All current models have exactly one SW input (index 0). Changes apply
+immediately, no restart needed.
+
+```bash
+# read all settings
+curl http://<ip>:8080/settings
+# switch input 0 to switch-edge mode driving relay 0
+# (the json content type is required or the server rejects the body)
+curl -X POST -H "Content-Type: application/json" \
+  http://<ip>:8080/settings -d '{"swInputMode0":2,"swInputRelayMap0":0}'
+# current input state; state is null until the first edge after app start
+curl "http://<ip>:8080/device/input?num=0"
+```
+
+## MQTT
+
+- `shellyelevatev2/<id>/switch_state` gets `PRESS` on contact close and
+  `RELEASE` on contact open in every mode. Previous versions only ever sent
+  `PRESS`, which left the Home Assistant binary_sensor stuck on.
+- In button mode, press gestures go to `shellyelevatev2/<id>/button/100` and a
+  matching HA event entity is announced via discovery.
+- On every (re)connect the current level is re-published so HA stays in sync.
+
+## JavaScript bridge
+
+`onButtonPressed(100 + input)` fires once per press in detached and button
+mode (on the press edge now, previously on release), and on every edge in the
+two switch modes.
+
+## Relay control and priv-app installs
+
+On newer models (XL/U1/X2i/X1i) the relay is driven through an init script
+(`ctl.start` on `cloud.shelly.<codename>.relayN`), which only works when the
+app runs as a system/priv-app. A plain `adb install` lacks that privilege —
+logcat then shows a harmless `Unable to set property "ctl.start" ... error
+code: 0x20` warning and the app falls back to a direct sysfs write, which
+drives the relay fine. Installing as priv-app (offered on first run, or
+`tools/install-privapp.sh`) removes the warning.
+
+## Upgrading note
+
+Previously the SW input never controlled the relay. The default is now
+**Button** driving relay 0, matching stock firmware: an external taster
+toggles the light out of the box, even without MQTT or Home Assistant. If you
+used the input purely as a sensor for automations, set `swInputMode0` to `0`
+(Detached) to keep the old behavior.

--- a/tools/generate-signing-keystore.sh
+++ b/tools/generate-signing-keystore.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Generate a release signing keystore and print the values for the four
+# SIGNING_* GitHub Actions secrets that release-apk.yml and pr-apk.yml use.
+# Without these secrets every CI build falls back to an ephemeral debug key,
+# so no two artifacts can update each other on a device.
+# Usage: ./generate-signing-keystore.sh [output-keystore] [alias]
+#   output-keystore Path for the new keystore (default: shellyelevate-release.keystore)
+#   alias           Key alias (default: shellyelevate)
+# Keep the keystore and password out of the repository and back them up:
+# losing them means future builds can no longer update existing installs.
+
+set -euo pipefail
+
+KEYSTORE="${1:-shellyelevate-release.keystore}"
+ALIAS="${2:-shellyelevate}"
+
+if [[ -e "$KEYSTORE" ]]; then
+  echo "Refusing to overwrite existing $KEYSTORE" >&2
+  exit 1
+fi
+
+command -v keytool >/dev/null || { echo "keytool not found (install a JDK)" >&2; exit 1; }
+
+# pkcs12 keystores use one password for store and key
+PASSWORD="$(openssl rand -base64 18)"
+
+keytool -genkeypair -keystore "$KEYSTORE" -alias "$ALIAS" \
+  -keyalg RSA -keysize 4096 -validity 10000 \
+  -storepass "$PASSWORD" -keypass "$PASSWORD" \
+  -dname "CN=ShellyElevate release, O=ShellyElevate"
+
+echo
+echo "Keystore written to $KEYSTORE - back it up together with the password."
+echo
+echo "Set the repository secrets (or paste the same values in the GitHub UI"
+echo "under Settings -> Secrets and variables -> Actions):"
+echo
+echo "  gh secret set SIGNING_KEY_ALIAS       --body \"$ALIAS\""
+echo "  gh secret set SIGNING_STORE_PASSWORD  --body \"$PASSWORD\""
+echo "  gh secret set SIGNING_KEY_PASSWORD    --body \"$PASSWORD\""
+echo "  gh secret set SIGNING_KEYSTORE_BASE64 --body \"\$(openssl base64 -A -in $KEYSTORE)\""


### PR DESCRIPTION
Fixes #29, #93 

* add sw input mode constants and pure state machine


Claude-Session: https://claude.ai/code/session_01FdbXCtBx5iM1nSWTGaD2jW

* add sw input handler and wire it into the application


Claude-Session: https://claude.ai/code/session_01FdbXCtBx5iM1nSWTGaD2jW

* route sw input edges from keyevents and the native monitor through the handler


Claude-Session: https://claude.ai/code/session_01FdbXCtBx5iM1nSWTGaD2jW

* expose sw input mode, relay target and invert in settings


Claude-Session: https://claude.ai/code/session_01FdbXCtBx5iM1nSWTGaD2jW

* publish initial sw input level and button mode discovery over mqtt


Claude-Session: https://claude.ai/code/session_01FdbXCtBx5iM1nSWTGaD2jW

* add /device/input state endpoint


Claude-Session: https://claude.ai/code/session_01FdbXCtBx5iM1nSWTGaD2jW

* add jvm tests for the sw input state machine


Claude-Session: https://claude.ai/code/session_01FdbXCtBx5iM1nSWTGaD2jW

* document sw input modes


Claude-Session: https://claude.ai/code/session_01FdbXCtBx5iM1nSWTGaD2jW

* label cally as wall display x1i per the official kb


Claude-Session: https://claude.ai/code/session_01FdbXCtBx5iM1nSWTGaD2jW

* fix follow mode test expectation to include the js event


Claude-Session: https://claude.ai/code/session_01FdbXCtBx5iM1nSWTGaD2jW

* note the json content type requirement in the sw input curl examples


Claude-Session: https://claude.ai/code/session_01FdbXCtBx5iM1nSWTGaD2jW

* add pr apk build workflow

runs unit tests and builds a release apk on every pull request, uploading it as a workflow artifact so changes can be sideloaded and live-tested before merging. signing secrets are optional: fork prs fall back to the debug key.


Claude-Session: https://claude.ai/code/session_01FdbXCtBx5iM1nSWTGaD2jW

* decode sw input keycodes as rising and falling edge pulses of one input

hardware testing on a wall display x1i showed the sw terminal reports each contact transition as a ~5ms down+up key pulse whose keycode encodes the direction: 141/KEY_F11 = line went active, 142/KEY_F12 = line went inactive. the old code treated 141 down/up as press/release and 142 as a second input, so falling edges were swallowed and multi-way taster circuits only toggled on every second press. the state machine now consumes decoded levels, only the pulse's down event is fed in, and the opposite-level debounce is replaced by a same-level duplicate window so genuine repeated presses still register.


Claude-Session: https://claude.ai/code/session_01FdbXCtBx5iM1nSWTGaD2jW

* warn when pr apks are signed with an ephemeral debug key and add a keystore generator

without the SIGNING_* secrets every ci run signs with a keystore generated fresh on that runner, so no artifact can ever update a previously installed one. the build step now surfaces that as a run warning and tools/ gains a script that generates a persistent keystore and prints the secrets to set.


Claude-Session: https://claude.ai/code/session_01FdbXCtBx5iM1nSWTGaD2jW

* print a portable base64 command from the keystore generator

base64 -w0 is gnu-only; bsd/macos base64 has no -w flag. openssl base64 -A produces single-line output on both platforms and the script already uses openssl anyway.


Claude-Session: https://claude.ai/code/session_01FdbXCtBx5iM1nSWTGaD2jW

---------