### PR TITLE
feat(webview): grant pages access to the microphone

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,7 @@
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.permission.WRITE_SETTINGS" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30"/>
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30"/>
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN"

--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/MainActivity.kt
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/MainActivity.kt
@@ -6,6 +6,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.content.pm.PackageManager
 import android.net.http.SslError
 import android.os.Bundle
 import android.util.Log
@@ -18,6 +19,7 @@ import android.webkit.RenderProcessGoneDetail
 import android.webkit.SslErrorHandler
 import android.webkit.WebChromeClient
 import android.webkit.ConsoleMessage
+import android.webkit.PermissionRequest
 import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
@@ -600,6 +602,25 @@ class MainActivity : ComponentActivity() {
             }
 
             webChromeClient = object : WebChromeClient() {
+                // A page may use the microphone when the app itself holds
+                // RECORD_AUDIO. Audio only: these displays have no camera, and
+                // nothing else is granted here.
+                override fun onPermissionRequest(request: PermissionRequest) {
+                    if (!request.resources.contains(PermissionRequest.RESOURCE_AUDIO_CAPTURE)) {
+                        request.deny()
+                        return
+                    }
+                    if (ContextCompat.checkSelfPermission(
+                            this@MainActivity, Manifest.permission.RECORD_AUDIO
+                        ) != PackageManager.PERMISSION_GRANTED
+                    ) {
+                        Log.w("MainActivity", "audio capture requested but RECORD_AUDIO is not granted")
+                        request.deny()
+                        return
+                    }
+                    request.grant(arrayOf(PermissionRequest.RESOURCE_AUDIO_CAPTURE))
+                }
+
                 override fun onConsoleMessage(consoleMessage: ConsoleMessage): Boolean {
                     val message = consoleMessage.message()
 


### PR DESCRIPTION
`getUserMedia({audio: true})` fails in the WebView, so nothing that needs capture works:
SIP/WebRTC intercoms, Home Assistant's Assist button, push-to-talk. Two separate causes,
and fixing only one of them still gives no audio.

1. The `WebChromeClient` in `configureWebView()` overrides only `onConsoleMessage`, so
   capture requests hit the default deny and the page sees `NotAllowedError`.
2. The manifest does not declare `MODIFY_AUDIO_SETTINGS`. Chromium wants it next to
   `RECORD_AUDIO`: without it `AudioManagerAndroid.setDevice()` returns false and
   `MakeLowLatencyInputStream` returns NULL, so the page gets `NotReadableError` and
   logcat has one line, `[ERROR:audio_manager_android.cc(326)] Unable to select audio
   device!`. It is a normal permission, so declaring it is the whole grant.

So: `onPermissionRequest` grants `RESOURCE_AUDIO_CAPTURE` when the app itself holds
`RECORD_AUDIO` and denies everything else - audio only, these displays have no camera -
plus the one permission line in the manifest.

Tested on a Wall Display (STARGATE, Android 7.0, WebView 119) over https: `getUserMedia`
returns a live 16 kHz mono track and an `AnalyserNode` on it reads real room noise, so the
capture path works and not just the permission check. Video still returns `NotFoundError`,
as it should. The native voice assistant is unaffected - it opens `AudioRecord` directly,
which needs only `RECORD_AUDIO`, and that is why this never showed up there.