### PR TITLE
Fix: respect "Wake on proximity" setting while screensaver is active

### DIFF
--- a/app/src/main/java/me/rapierxbox/shellyelevatev2/screensavers/ScreenSaverManager.java
+++ b/app/src/main/java/me/rapierxbox/shellyelevatev2/screensavers/ScreenSaverManager.java
@@ -304,15 +304,10 @@ public class ScreenSaverManager extends BroadcastReceiver {
         }
         lastNearState = isNear;
 
-        if (screenSaverRunning && isNear) {
-            // Force a wake even when SP_WAKE_ON_PROXIMITY is off, otherwise the
-            // user would be left with a black screen they can't recover from.
-            stopScreenSaver();
-            lastProximityWakeTime = now;
-            keepAwakeAfterProximity(now, keepAwakeMs);
-        } else if (wakeOnProximity && isNear) {
+        if (wakeOnProximity && isNear) {
             if (now - lastProximityWakeTime < 1000L) return;
             lastProximityWakeTime = now;
+            if (screenSaverRunning) stopScreenSaver();
             keepAwakeAfterProximity(now, keepAwakeMs);
         }
     }


### PR DESCRIPTION
Proximity events previously bypassed `wakeOnProximity` whenever the screensaver was already running, force-waking the screen regardless of the setting (only applied before the screensaver started).

Removed the override so the preference is honored consistently; touch still wakes the display independently, so no black-screen deadlock risk.

Tested on X2 and X2i (old and new version)